### PR TITLE
feat: add otelite import command for JSONL telemetry files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Open `http://localhost:3000` in your browser to view telemetry.
 - **Web Dashboard**: View and filter telemetry data at `http://localhost:3000`
 - **Terminal UI**: Full-featured TUI with `otelite tui`
 - **CLI**: Query and export data with `otelite logs`, `otelite traces`, `otelite metrics`, `otelite usage`
+- **Offline import**: Load telemetry from JSONL files with `otelite import` — useful for CI artifacts and air-gapped environments
 - **Single Binary**: Zero runtime dependencies
 - **GenAI/LLM support**: First-class OTel GenAI semconv — token counts, cache hits, tool calls, model routing
 

--- a/crates/otelite/src/commands/import.rs
+++ b/crates/otelite/src/commands/import.rs
@@ -1,0 +1,190 @@
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use otelite_receiver::{conversion, protocol};
+use otelite_storage::{sqlite::SqliteBackend, StorageBackend, StorageConfig};
+
+use crate::error::{Error, Result};
+
+enum SignalType {
+    Metrics,
+    Logs,
+    Traces,
+}
+
+fn detect_signal_type(line: &str) -> Result<SignalType> {
+    let v: serde_json::Value = serde_json::from_str(line)?;
+    if v.get("resourceMetrics").is_some() {
+        Ok(SignalType::Metrics)
+    } else if v.get("resourceLogs").is_some() {
+        Ok(SignalType::Logs)
+    } else if v.get("resourceSpans").is_some() {
+        Ok(SignalType::Traces)
+    } else {
+        Err(Error::InvalidArgument(
+            "Cannot detect signal type from JSON keys (expected resourceMetrics, resourceLogs, or resourceSpans). Use --signal-type to specify.".to_string(),
+        ))
+    }
+}
+
+fn parse_signal_type(s: &str) -> Result<SignalType> {
+    match s {
+        "metrics" => Ok(SignalType::Metrics),
+        "logs" => Ok(SignalType::Logs),
+        "traces" => Ok(SignalType::Traces),
+        other => Err(Error::InvalidArgument(format!(
+            "Unknown signal type '{}'. Use metrics, logs, or traces.",
+            other
+        ))),
+    }
+}
+
+pub async fn handle_import(
+    file: &str,
+    signal_type: Option<&str>,
+    storage_path: Option<&str>,
+) -> Result<()> {
+    // Validate explicit signal type before touching the filesystem.
+    if let Some(s) = signal_type {
+        parse_signal_type(s)?;
+    }
+
+    let reader: Box<dyn BufRead> = if file == "-" {
+        Box::new(BufReader::new(std::io::stdin()))
+    } else {
+        let f = std::fs::File::open(file).map_err(|e| {
+            Error::IoError(std::io::Error::new(
+                e.kind(),
+                format!("Cannot open '{}': {}", file, e),
+            ))
+        })?;
+        Box::new(BufReader::new(f))
+    };
+
+    let data_dir: PathBuf = match storage_path {
+        Some(p) => PathBuf::from(p),
+        None => StorageConfig::default().data_dir,
+    };
+
+    let config = StorageConfig::default()
+        .with_data_dir(data_dir)
+        .with_auto_purge(false);
+
+    let mut storage = SqliteBackend::new(config);
+    storage.initialize().await?;
+
+    let mut lines = reader.lines();
+    let mut imported: usize = 0;
+    let mut skipped: usize = 0;
+    let mut errors: usize = 0;
+    let mut line_number: usize = 0;
+
+    // Read until we find the first non-empty line (needed for auto-detection).
+    let mut first_line: Option<String> = None;
+    for raw in lines.by_ref() {
+        line_number += 1;
+        let line = raw?;
+        let trimmed = line.trim().to_string();
+        if trimmed.is_empty() {
+            skipped += 1;
+            continue;
+        }
+        first_line = Some(trimmed);
+        break;
+    }
+
+    let first = match first_line {
+        None => {
+            eprintln!("Import complete: 0 records (file is empty)");
+            storage.close().await?;
+            return Ok(());
+        },
+        Some(l) => l,
+    };
+
+    // safe: explicit signal type was already validated above
+    let sig = match signal_type {
+        Some(s) => parse_signal_type(s)?,
+        None => detect_signal_type(&first)?,
+    };
+
+    // Chain the first line back in so it gets processed with the rest.
+    let all_lines =
+        std::iter::once(Ok(first)).chain(lines.by_ref().map(|r| r.map(|l| l.trim().to_string())));
+
+    for raw in all_lines {
+        let line = raw?;
+        // Always advance line_number so error messages are accurate.
+        line_number += 1;
+        if line.is_empty() {
+            skipped += 1;
+            continue;
+        }
+        let data = line.as_bytes();
+        match sig {
+            SignalType::Metrics => match protocol::parse_metrics_json(data) {
+                Err(e) => {
+                    eprintln!("Warning: line {}: {}", line_number, e);
+                    errors += 1;
+                },
+                Ok(req) => {
+                    for m in &conversion::convert_metrics(req) {
+                        if let Err(e) = storage.write_metric(m).await {
+                            eprintln!("Warning: line {}: write failed: {}", line_number, e);
+                            errors += 1;
+                        } else {
+                            imported += 1;
+                        }
+                    }
+                },
+            },
+            SignalType::Logs => match protocol::parse_logs_json(data) {
+                Err(e) => {
+                    eprintln!("Warning: line {}: {}", line_number, e);
+                    errors += 1;
+                },
+                Ok(req) => {
+                    for log in &conversion::convert_logs(req) {
+                        if let Err(e) = storage.write_log(log).await {
+                            eprintln!("Warning: line {}: write failed: {}", line_number, e);
+                            errors += 1;
+                        } else {
+                            imported += 1;
+                        }
+                    }
+                },
+            },
+            SignalType::Traces => match protocol::parse_traces_json(data) {
+                Err(e) => {
+                    eprintln!("Warning: line {}: {}", line_number, e);
+                    errors += 1;
+                },
+                Ok(req) => {
+                    for trace in &conversion::convert_traces(req) {
+                        for span in &trace.spans {
+                            if let Err(e) = storage.write_span(span).await {
+                                eprintln!("Warning: line {}: write failed: {}", line_number, e);
+                                errors += 1;
+                            } else {
+                                imported += 1;
+                            }
+                        }
+                    }
+                },
+            },
+        }
+    }
+
+    storage.close().await?;
+
+    eprintln!(
+        "Import complete: {} records imported ({} errors, {} empty lines skipped)",
+        imported, errors, skipped
+    );
+
+    if imported == 0 && errors > 0 {
+        return Err(Error::ApiError("All lines failed to import".to_string()));
+    }
+
+    Ok(())
+}

--- a/crates/otelite/src/commands/mod.rs
+++ b/crates/otelite/src/commands/mod.rs
@@ -1,5 +1,6 @@
 //! Command handlers for otelite CLI
 
+pub mod import;
 pub mod logs;
 pub mod metrics;
 pub mod service;

--- a/crates/otelite/src/error.rs
+++ b/crates/otelite/src/error.rs
@@ -24,6 +24,8 @@ pub enum Error {
     JsonError(serde_json::Error),
     /// IO error
     IoError(std::io::Error),
+    /// Storage error
+    StorageError(String),
 }
 
 impl fmt::Display for Error {
@@ -37,6 +39,7 @@ impl fmt::Display for Error {
             Error::HttpError(err) => write!(f, "HTTP error: {}", err),
             Error::JsonError(err) => write!(f, "JSON error: {}", err),
             Error::IoError(err) => write!(f, "IO error: {}", err),
+            Error::StorageError(msg) => write!(f, "Storage error: {}", msg),
         }
     }
 }
@@ -96,6 +99,12 @@ impl From<otelite_client::Error> for Error {
 impl From<std::io::Error> for Error {
     fn from(err: std::io::Error) -> Self {
         Error::IoError(err)
+    }
+}
+
+impl From<otelite_storage::StorageError> for Error {
+    fn from(e: otelite_storage::StorageError) -> Self {
+        Error::StorageError(e.to_string())
     }
 }
 

--- a/crates/otelite/src/main.rs
+++ b/crates/otelite/src/main.rs
@@ -67,27 +67,27 @@ enum Commands {
     /// Start the server with OTLP receivers in the foreground (default if no subcommand)
     #[command(
         alias = "dashboard",
-        after_help = "Examples:\n  otelite serve\n  otelite serve --addr 0.0.0.0:8080 --storage-path /data/otelite.db"
+        after_help = "Examples:\n  otelite serve\n  otelite serve --addr 0.0.0.0:8080 --storage-path /data/myproject"
     )]
     Serve {
         /// Server bind address
         #[arg(long, default_value = "127.0.0.1:3000")]
         addr: SocketAddr,
 
-        /// Storage database path
+        /// Directory for the SQLite database (database file is always named otelite.db inside this directory)
         #[arg(long, default_value = "otelite.db")]
         storage_path: String,
     },
     /// Run `serve` as a background daemon
     #[command(
-        after_help = "Examples:\n  otelite start\n  otelite start --addr 0.0.0.0:3000 --storage-path /data/otelite.db"
+        after_help = "Examples:\n  otelite start\n  otelite start --addr 0.0.0.0:3000 --storage-path /data/myproject"
     )]
     Start {
         /// Server bind address
         #[arg(long, default_value = "127.0.0.1:3000")]
         addr: String,
 
-        /// Storage database path
+        /// Directory for the SQLite database (database file is always named otelite.db inside this directory)
         #[arg(long, default_value = "otelite.db")]
         storage_path: String,
     },
@@ -97,14 +97,14 @@ enum Commands {
     /// Stop the running daemon and start a fresh one.
     /// Picks up a freshly compiled binary if you ran `cargo build --release` first.
     #[command(
-        after_help = "Examples:\n  otelite restart\n  otelite restart --addr 0.0.0.0:3000 --storage-path /data/otelite.db"
+        after_help = "Examples:\n  otelite restart\n  otelite restart --addr 0.0.0.0:3000 --storage-path /data/myproject"
     )]
     Restart {
         /// Server bind address
         #[arg(long, default_value = "127.0.0.1:3000")]
         addr: String,
 
-        /// Storage database path
+        /// Directory for the SQLite database (database file is always named otelite.db inside this directory)
         #[arg(long, default_value = "otelite.db")]
         storage_path: String,
     },
@@ -168,6 +168,22 @@ enum Commands {
         /// Enable debug logging
         #[arg(long)]
         debug: bool,
+    },
+    /// Import telemetry data from a JSONL file into a local database (no server required)
+    #[command(
+        after_help = "Each line must be a complete OTLP JSON export request (ExportMetricsServiceRequest, ExportLogsServiceRequest, or ExportTraceServiceRequest).\n\nExamples:\n  otelite import ci-metrics.jsonl\n  otelite import --signal-type metrics build.jsonl\n  otelite import --storage-path ./ci-run-42 build.jsonl\n  otelite serve --storage-path ./ci-run-42   # browse imported data"
+    )]
+    Import {
+        /// Path to JSONL file (use '-' to read from stdin)
+        file: String,
+
+        /// Signal type to import: metrics, logs, or traces (auto-detected if omitted)
+        #[arg(long)]
+        signal_type: Option<String>,
+
+        /// Data directory for the target database (default: ~/.otelite/data)
+        #[arg(long)]
+        storage_path: Option<String>,
     },
 }
 
@@ -481,6 +497,14 @@ async fn run_cli() -> Result<()> {
             view,
             debug,
         }) => handle_tui_command(api_url, refresh_interval, view, debug).await,
+        Some(Commands::Import {
+            file,
+            signal_type,
+            storage_path,
+        }) => {
+            commands::import::handle_import(&file, signal_type.as_deref(), storage_path.as_deref())
+                .await
+        },
         None => {
             // Default: run dashboard
             run_dashboard("127.0.0.1:3000".parse().unwrap(), "otelite.db".to_string()).await

--- a/crates/otelite/tests/import_test.rs
+++ b/crates/otelite/tests/import_test.rs
@@ -1,0 +1,194 @@
+use assert_cmd::Command;
+use std::io::Write;
+use tempfile::TempDir;
+
+// One-liner OTLP JSON fixtures (matching sample_*.json in otelite-core)
+const METRICS_LINE: &str = r#"{"resourceMetrics":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"ci-runner"}}]},"scopeMetrics":[{"metrics":[{"name":"ci.duration","unit":"s","gauge":{"dataPoints":[{"asDouble":42.5,"timeUnixNano":"1713355200000000000"}]}}]}]}]}"#;
+const LOGS_LINE: &str = r#"{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"ci-runner"}}]},"scopeLogs":[{"logRecords":[{"timeUnixNano":"1713355200000000000","severityNumber":9,"severityText":"INFO","body":{"stringValue":"build succeeded"}}]}]}]}"#;
+const TRACES_LINE: &str = r#"{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"ci-runner"}}]},"scopeSpans":[{"spans":[{"traceId":"0102030405060708090a0b0c0d0e0f10","spanId":"0102030405060708","name":"ci-step","kind":1,"startTimeUnixNano":"1713355200000000000","endTimeUnixNano":"1713355201000000000"}]}]}]}"#;
+
+fn write_jsonl(dir: &TempDir, name: &str, lines: &[&str]) -> std::path::PathBuf {
+    let path = dir.path().join(name);
+    let mut f = std::fs::File::create(&path).unwrap();
+    for line in lines {
+        writeln!(f, "{}", line).unwrap();
+    }
+    path
+}
+
+fn otelite_cmd() -> Command {
+    Command::cargo_bin("otelite").unwrap()
+}
+
+#[test]
+fn import_metrics_creates_db() {
+    let data_dir = TempDir::new().unwrap();
+    let input_dir = TempDir::new().unwrap();
+    let jsonl = write_jsonl(&input_dir, "metrics.jsonl", &[METRICS_LINE]);
+
+    otelite_cmd()
+        .args([
+            "import",
+            jsonl.to_str().unwrap(),
+            "--signal-type",
+            "metrics",
+            "--storage-path",
+            data_dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    assert!(data_dir.path().join("otelite.db").exists());
+}
+
+#[test]
+fn import_logs_auto_detect() {
+    let data_dir = TempDir::new().unwrap();
+    let input_dir = TempDir::new().unwrap();
+    let jsonl = write_jsonl(&input_dir, "logs.jsonl", &[LOGS_LINE]);
+
+    // No --signal-type — rely on auto-detection from "resourceLogs" key
+    otelite_cmd()
+        .args([
+            "import",
+            jsonl.to_str().unwrap(),
+            "--storage-path",
+            data_dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn import_traces_auto_detect() {
+    let data_dir = TempDir::new().unwrap();
+    let input_dir = TempDir::new().unwrap();
+    let jsonl = write_jsonl(&input_dir, "traces.jsonl", &[TRACES_LINE]);
+
+    otelite_cmd()
+        .args([
+            "import",
+            jsonl.to_str().unwrap(),
+            "--storage-path",
+            data_dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn import_multiple_lines() {
+    let data_dir = TempDir::new().unwrap();
+    let input_dir = TempDir::new().unwrap();
+    // Three metrics lines — should import 3 data points
+    let jsonl = write_jsonl(
+        &input_dir,
+        "multi.jsonl",
+        &[METRICS_LINE, METRICS_LINE, METRICS_LINE],
+    );
+
+    otelite_cmd()
+        .args([
+            "import",
+            jsonl.to_str().unwrap(),
+            "--signal-type",
+            "metrics",
+            "--storage-path",
+            data_dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn import_skips_invalid_lines() {
+    let data_dir = TempDir::new().unwrap();
+    let input_dir = TempDir::new().unwrap();
+    let jsonl = write_jsonl(
+        &input_dir,
+        "mixed.jsonl",
+        &[METRICS_LINE, "{ not valid json {{", METRICS_LINE],
+    );
+
+    // Should succeed even with one bad line
+    otelite_cmd()
+        .args([
+            "import",
+            jsonl.to_str().unwrap(),
+            "--signal-type",
+            "metrics",
+            "--storage-path",
+            data_dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn import_skips_empty_lines() {
+    let data_dir = TempDir::new().unwrap();
+    let input_dir = TempDir::new().unwrap();
+    let jsonl = write_jsonl(
+        &input_dir,
+        "spaced.jsonl",
+        &["", METRICS_LINE, "", METRICS_LINE],
+    );
+
+    otelite_cmd()
+        .args([
+            "import",
+            jsonl.to_str().unwrap(),
+            "--signal-type",
+            "metrics",
+            "--storage-path",
+            data_dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn import_empty_file_succeeds() {
+    let data_dir = TempDir::new().unwrap();
+    let input_dir = TempDir::new().unwrap();
+    let jsonl = write_jsonl(&input_dir, "empty.jsonl", &[]);
+
+    otelite_cmd()
+        .args([
+            "import",
+            jsonl.to_str().unwrap(),
+            "--signal-type",
+            "metrics",
+            "--storage-path",
+            data_dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn import_nonexistent_file_fails() {
+    otelite_cmd()
+        .args(["import", "/tmp/does-not-exist-otelite-test.jsonl"])
+        .assert()
+        .failure();
+}
+
+#[test]
+fn import_unknown_signal_type_fails() {
+    let data_dir = TempDir::new().unwrap();
+    let input_dir = TempDir::new().unwrap();
+    let jsonl = write_jsonl(&input_dir, "m.jsonl", &[METRICS_LINE]);
+
+    otelite_cmd()
+        .args([
+            "import",
+            jsonl.to_str().unwrap(),
+            "--signal-type",
+            "events",
+            "--storage-path",
+            data_dir.path().to_str().unwrap(),
+        ])
+        .assert()
+        .failure();
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -202,6 +202,55 @@ Flags:
 
 ---
 
+## Importing from files
+
+`otelite import` loads telemetry from a newline-delimited JSON file (JSONL) without a running
+receiver. Each line must be a complete OTLP JSON export request — the format produced by standard
+OTLP file exporters.
+
+### Import into the default database
+
+```bash
+otelite import telemetry.jsonl
+```
+
+### Import into an isolated database
+
+Useful for CI artifacts or any data you want to keep separate from your live session:
+
+```bash
+otelite import telemetry.jsonl --storage-path ./ci-run-42
+otelite serve --storage-path ./ci-run-42    # browse the imported data
+```
+
+### Force signal type (skip auto-detection)
+
+```bash
+otelite import metrics.jsonl --signal-type metrics
+otelite import spans.jsonl   --signal-type traces
+otelite import app.jsonl     --signal-type logs
+```
+
+### Read from stdin
+
+```bash
+cat metrics.jsonl | otelite import -
+```
+
+Signal type is auto-detected from the top-level key of the first non-empty line
+(`resourceMetrics`, `resourceLogs`, or `resourceSpans`). A summary is printed to stderr on
+completion:
+
+```text
+Import complete: 1247 records imported (0 errors, 3 empty lines skipped)
+```
+
+> **Note on historical data**: the metrics web UI time range selector offers presets up to 24h.
+> Data older than that is still stored and queryable via `otelite metrics list`, but will not
+> appear in the dashboard graphs without selecting a wider time range.
+
+---
+
 ## Common patterns
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds `otelite import <file>` — a standalone CLI command that ingests OTLP JSON telemetry from a newline-delimited file, no running server required
- Each line must be a complete OTLP JSON export request (`ExportMetricsServiceRequest`, `ExportLogsServiceRequest`, or `ExportTraceServiceRequest`) — the format produced by standard OTLP file exporters
- Signal type auto-detected from the first line's top-level key (`resourceMetrics` / `resourceLogs` / `resourceSpans`); overridable with `--signal-type`
- `--storage-path` targets a separate data directory so imported data stays isolated from the live DB; browse it with `otelite serve --storage-path <dir>`
- Fixes misleading `--storage-path` help text on `serve`/`start`/`restart` (the flag is a data directory, not a file path)

## Before / after

```bash
# Before: no way to load file-captured telemetry into otelite

# After:
otelite import ./ci-build-metrics.jsonl --storage-path ./ci-run-42
otelite serve --storage-path ./ci-run-42   # browse in web UI / TUI
```

## Known limitation

The metrics web UI time range selector only offers 5m / 1h / 6h / 24h presets. Imported historical data with timestamps older than 24h will not appear in any preset. An "all time" or custom date range option would improve the experience — tracked separately.

## Test plan

- [x] 9 integration tests covering metrics/logs/traces import, auto-detection, error tolerance (mixed valid/invalid lines), separate DB, empty file, nonexistent file, unknown signal type
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --check`

Closes #43