### PR TITLE
fix: reject malformed metric attrs filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ have to work around), not implementation detail.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Metrics API now rejects malformed `attrs` filters instead of ignoring them.**
+  `GET /api/metrics?attrs=not-json` returns `400 Bad Request` with a clear
+  message, so users no longer receive unfiltered metric results after a typo in
+  the JSON filter parameter.
+
 ## [0.1.39] - 2026-05-15
 
 ### Fixed

--- a/crates/otelite-api/src/api/metrics.rs
+++ b/crates/otelite-api/src/api/metrics.rs
@@ -81,6 +81,7 @@ pub struct TimeBucket {
     params(MetricsQuery),
     responses(
         (status = 200, description = "List of metrics", body = Vec<MetricResponse>),
+        (status = 400, description = "Invalid query parameters", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "metrics"
@@ -148,20 +149,26 @@ pub async fn list_metrics(
                 op: String,
                 value: Option<String>,
             }
-            if let Ok(filters) = serde_json::from_str::<Vec<AttrFilter>>(attrs_json) {
-                for f in filters {
-                    let op = match f.op.as_str() {
-                        "=" => Operator::Equal,
-                        "!=" => Operator::NotEqual,
-                        _ => continue,
-                    };
-                    if let Some(v) = f.value {
-                        params.predicates.push(QueryPredicate {
-                            field: f.key,
-                            operator: op,
-                            value: QueryValue::String(v),
-                        });
-                    }
+            let filters = serde_json::from_str::<Vec<AttrFilter>>(attrs_json).map_err(|e| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse::bad_request(format!(
+                        "attrs must be valid JSON attribute filters: {e}"
+                    ))),
+                )
+            })?;
+            for f in filters {
+                let op = match f.op.as_str() {
+                    "=" => Operator::Equal,
+                    "!=" => Operator::NotEqual,
+                    _ => continue,
+                };
+                if let Some(v) = f.value {
+                    params.predicates.push(QueryPredicate {
+                        field: f.key,
+                        operator: op,
+                        value: QueryValue::String(v),
+                    });
                 }
             }
         }

--- a/crates/otelite-api/tests/api_integration_test.rs
+++ b/crates/otelite-api/tests/api_integration_test.rs
@@ -5,7 +5,9 @@ use http_body_util::BodyExt;
 use otelite_api::api::health::HealthResponse;
 use otelite_api::api::metrics::AggregateResponse;
 use otelite_api::server::{AppState, QueryCache};
-use otelite_core::api::{LogEntry, LogsResponse, MetricResponse, TraceDetail, TracesResponse};
+use otelite_core::api::{
+    ErrorResponse, LogEntry, LogsResponse, MetricResponse, TraceDetail, TracesResponse,
+};
 use otelite_core::telemetry::log::{LogRecord, SeverityLevel};
 use otelite_core::telemetry::metric::{Metric, MetricType};
 use otelite_core::telemetry::trace::{Span, SpanKind, SpanStatus, StatusCode as SpanStatusCode};
@@ -686,6 +688,31 @@ async fn test_list_metrics_empty() {
     let metrics: Vec<MetricResponse> = serde_json::from_slice(&body).unwrap();
 
     assert_eq!(metrics.len(), 0);
+}
+
+#[tokio::test]
+async fn test_list_metrics_rejects_malformed_attrs_json() {
+    let (storage, _tmp) = setup_test_storage().await;
+    let app = build_test_router(storage);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/metrics?attrs=not-json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let error: ErrorResponse = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(error.code, "BAD_REQUEST");
+    assert!(error.error.contains("attrs"));
+    assert!(error.error.contains("valid JSON"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
Summary:
- Return 400 Bad Request when the metrics API receives malformed `attrs` JSON instead of silently ignoring the filter.
- Keep valid `attrs` filters working as before while reporting a descriptive parse error for invalid JSON.
- Add an integration test for `/api/metrics?attrs=not-json` and document the user-visible fix in the changelog.

Fixes #71

Testing:
- `cargo test -p otelite-api test_list_metrics_rejects_malformed_attrs_json -- --nocapture`
- `cargo fmt --check && git diff --check && cargo test -p otelite-api`
- `cargo clippy -p otelite-api --all-targets -- -D warnings`
- `cargo build --workspace`
- `cargo test --workspace -- --nocapture`
- `cargo clippy --workspace --all-targets -- -D warnings`
