### PR TITLE
fix: validate API time ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ have to work around), not implementation detail.
 
 ## [Unreleased]
 
+### Fixed
+
+- **API time filters now reject invalid ranges.** Logs, traces, and metrics
+  endpoints return `400 Bad Request` for negative timestamps or
+  `start_time >= end_time` instead of silently returning an empty response;
+  valid ranges with no data still return a normal empty `200 OK` response.
+
 ## [0.1.39] - 2026-05-15
 
 ### Fixed

--- a/crates/otelite-api/src/api/logs.rs
+++ b/crates/otelite-api/src/api/logs.rs
@@ -1,3 +1,4 @@
+use super::validate_time_range;
 use crate::server::{AppState, QueryCache};
 use axum::{
     extract::{Path, Query, State},
@@ -79,6 +80,7 @@ fn default_limit() -> usize {
     params(LogsQuery),
     responses(
         (status = 200, description = "List of logs matching query", body = LogsResponse),
+        (status = 400, description = "Invalid time range", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "logs"
@@ -87,6 +89,8 @@ pub async fn list_logs(
     State(state): State<AppState>,
     Query(params): Query<LogsQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    validate_time_range(params.start_time, params.end_time)?;
+
     // Check cache first
     let cache_key = QueryCache::make_key(&params);
     if let Some(cached) = state.cache.logs.get(&cache_key) {
@@ -301,7 +305,7 @@ fn default_format() -> String {
     params(ExportQuery),
     responses(
         (status = 200, description = "Exported logs in requested format"),
-        (status = 400, description = "Invalid format parameter", body = ErrorResponse),
+        (status = 400, description = "Invalid format parameter or time range", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "logs"
@@ -310,6 +314,8 @@ pub async fn export_logs(
     State(state): State<AppState>,
     Query(params): Query<ExportQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    validate_time_range(params.filters.start_time, params.filters.end_time)?;
+
     // Build query parameters (no limit for export, but cap at 10000)
     let mut query = QueryParams {
         start_time: params.filters.start_time,

--- a/crates/otelite-api/src/api/metrics.rs
+++ b/crates/otelite-api/src/api/metrics.rs
@@ -1,3 +1,4 @@
+use super::validate_time_range;
 use crate::server::{AppState, QueryCache};
 use axum::{
     extract::{Query, State},
@@ -81,6 +82,7 @@ pub struct TimeBucket {
     params(MetricsQuery),
     responses(
         (status = 200, description = "List of metrics", body = Vec<MetricResponse>),
+        (status = 400, description = "Invalid time range", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "metrics"
@@ -89,6 +91,8 @@ pub async fn list_metrics(
     State(state): State<AppState>,
     Query(query): Query<MetricsQuery>,
 ) -> Result<Json<Vec<MetricResponse>>, (StatusCode, Json<ErrorResponse>)> {
+    validate_time_range(query.start_time, query.end_time)?;
+
     // Check cache first
     let cache_key = QueryCache::make_key(&query);
     if let Some(cached) = state.cache.metrics.get(&cache_key) {
@@ -314,7 +318,7 @@ pub async fn list_metric_names(
     params(AggregateQuery),
     responses(
         (status = 200, description = "Aggregated metric result (count=0 if metric exists but no data in the requested window)", body = AggregateResponse),
-        (status = 400, description = "Invalid aggregation function", body = ErrorResponse),
+        (status = 400, description = "Invalid aggregation function or time range", body = ErrorResponse),
         (status = 404, description = "Metric name has never been ingested", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
@@ -324,6 +328,8 @@ pub async fn aggregate_metrics(
     State(state): State<AppState>,
     Query(query): Query<AggregateQuery>,
 ) -> Result<Json<AggregateResponse>, (StatusCode, Json<ErrorResponse>)> {
+    validate_time_range(query.start_time, query.end_time)?;
+
     // Check cache first
     let cache_key = QueryCache::make_key(&query);
     if let Some(cached) = state.cache.metrics.get(&cache_key) {
@@ -776,6 +782,7 @@ pub struct TimeseriesQuery {
     params(MetricsQuery),
     responses(
         (status = 200, description = "Exported metrics in JSON format"),
+        (status = 400, description = "Invalid time range", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "metrics"
@@ -784,6 +791,8 @@ pub async fn export_metrics(
     State(state): State<AppState>,
     Query(query): Query<MetricsQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    validate_time_range(query.start_time, query.end_time)?;
+
     // Build query parameters
     let mut params = QueryParams::default();
 

--- a/crates/otelite-api/src/api/mod.rs
+++ b/crates/otelite-api/src/api/mod.rs
@@ -1,5 +1,8 @@
 // API module
 
+use axum::{http::StatusCode, Json};
+use otelite_core::api::ErrorResponse;
+
 pub mod admin;
 pub mod genai;
 pub mod health;
@@ -13,3 +16,35 @@ pub mod traces;
 pub use genai::get_token_usage;
 pub use health::health_check;
 pub use help::api_help;
+
+pub(crate) fn validate_time_range(
+    start_time: Option<i64>,
+    end_time: Option<i64>,
+) -> Result<(), (StatusCode, Json<ErrorResponse>)> {
+    if let Some(start_time) = start_time {
+        if start_time < 0 {
+            return Err(time_range_error("start_time must be non-negative"));
+        }
+    }
+
+    if let Some(end_time) = end_time {
+        if end_time < 0 {
+            return Err(time_range_error("end_time must be non-negative"));
+        }
+    }
+
+    if let (Some(start_time), Some(end_time)) = (start_time, end_time) {
+        if start_time >= end_time {
+            return Err(time_range_error("start_time must be less than end_time"));
+        }
+    }
+
+    Ok(())
+}
+
+fn time_range_error(message: &'static str) -> (StatusCode, Json<ErrorResponse>) {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(ErrorResponse::bad_request(message)),
+    )
+}

--- a/crates/otelite-api/src/api/traces.rs
+++ b/crates/otelite-api/src/api/traces.rs
@@ -1,3 +1,4 @@
+use super::validate_time_range;
 use crate::server::{AppState, QueryCache};
 use axum::{
     extract::{Path, Query, State},
@@ -75,6 +76,7 @@ fn default_limit() -> usize {
     params(TracesQuery),
     responses(
         (status = 200, description = "List of traces matching query", body = TracesResponse),
+        (status = 400, description = "Invalid time range", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "traces"
@@ -83,6 +85,8 @@ pub async fn list_traces(
     State(state): State<AppState>,
     Query(params): Query<TracesQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    validate_time_range(params.start_time, params.end_time)?;
+
     // Check cache first
     let cache_key = QueryCache::make_key(&params);
     if let Some(cached) = state.cache.traces.get(&cache_key) {
@@ -363,7 +367,7 @@ fn default_format() -> String {
     params(ExportQuery),
     responses(
         (status = 200, description = "Exported traces in JSON format"),
-        (status = 400, description = "Invalid format parameter", body = ErrorResponse),
+        (status = 400, description = "Invalid format parameter or time range", body = ErrorResponse),
         (status = 500, description = "Internal server error", body = ErrorResponse)
     ),
     tag = "traces"
@@ -372,6 +376,8 @@ pub async fn export_traces(
     State(state): State<AppState>,
     Query(params): Query<ExportQuery>,
 ) -> Result<impl IntoResponse, (StatusCode, Json<ErrorResponse>)> {
+    validate_time_range(params.filters.start_time, params.filters.end_time)?;
+
     // Build query parameters (no limit for export, but cap at 10000)
     let query = QueryParams {
         start_time: params.filters.start_time,

--- a/crates/otelite-api/tests/api_integration_test.rs
+++ b/crates/otelite-api/tests/api_integration_test.rs
@@ -162,6 +162,50 @@ fn create_test_metric(name: &str, timestamp: i64, value: f64) -> Metric {
 }
 
 #[tokio::test]
+async fn test_time_range_validation_rejects_invalid_list_queries() {
+    let (storage, _tmp) = setup_test_storage().await;
+    let app = build_test_router(storage);
+
+    let invalid_queries = [
+        "/api/logs?start_time=2000&end_time=1000",
+        "/api/traces?start_time=-1&end_time=1000",
+        "/api/metrics?start_time=1000&end_time=-1",
+    ];
+
+    for uri in invalid_queries {
+        let response = app
+            .clone()
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "uri: {uri}");
+    }
+}
+
+#[tokio::test]
+async fn test_time_range_validation_allows_valid_empty_list_queries() {
+    let (storage, _tmp) = setup_test_storage().await;
+    let app = build_test_router(storage);
+
+    let valid_empty_queries = [
+        "/api/logs?start_time=1000&end_time=2000",
+        "/api/traces?start_time=1000&end_time=2000",
+        "/api/metrics?start_time=1000&end_time=2000",
+    ];
+
+    for uri in valid_empty_queries {
+        let response = app
+            .clone()
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK, "uri: {uri}");
+    }
+}
+
+#[tokio::test]
 async fn test_health_check() {
     let (storage, _tmp) = setup_test_storage().await;
     let app = build_test_router(storage);


### PR DESCRIPTION
## Summary

- add a shared API time-range validator for optional `start_time` / `end_time` query params
- return `400 Bad Request` for negative timestamps or `start_time >= end_time` before cache/storage lookup
- apply the validator to logs, traces, and metrics list/export/aggregate handlers
- add HTTP regression coverage for invalid ranges and valid empty ranges
- document the user-visible API behavior change in `CHANGELOG.md`

Fixes #72

## Testing

- RED: `cargo test -p otelite-api test_time_range_validation_rejects_invalid_list_queries -- --nocapture` failed before the fix with `left: 200`, `right: 400` for `/api/logs?start_time=2000&end_time=1000`
- `cargo test -p otelite-api test_time_range_validation_rejects_invalid_list_queries -- --nocapture`
- `cargo test -p otelite-api test_time_range_validation_allows_valid_empty_list_queries -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p otelite-api`
- `cargo clippy -p otelite-api --all-targets -- -D warnings`
- `cargo build --workspace && cargo test --workspace && cargo clippy --workspace --all-targets -- -D warnings`
