### PR TITLE
feat: nix support

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,50 @@
+name: Nix
+
+on:
+  push:
+    branches: [main, develop]
+    paths:
+      - flake.nix
+      - flake.lock
+      - nix/**
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - rustfmt.toml
+      - clippy.toml
+      - .github/workflows/nix.yml
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - flake.nix
+      - flake.lock
+      - nix/**
+      - Cargo.toml
+      - Cargo.lock
+      - rust-toolchain.toml
+      - rustfmt.toml
+      - clippy.toml
+      - .github/workflows/nix.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  nix-check:
+    name: Flake Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v22
+
+      - name: Enable Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@v14
+        with:
+          use-flakehub: false
+
+      - name: Check flake
+        run: nix flake check --print-build-logs

--- a/.gitignore
+++ b/.gitignore
@@ -5,12 +5,16 @@ release/
 *.rs.bk
 *.rlib
 *.prof*
-Cargo.lock  # For applications; libraries should commit this
 
 # Environment variables
 .env
 .env.local
 .env.*.local
+.direnv/
+
+# Nix build results
+result
+result-*
 
 # IDE and editor files
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ have to work around), not implementation detail.
 
 ## [Unreleased]
 
+### Added
+
+- **Install and run Otelite with Nix on Linux and Apple Silicon.** The flake also
+  provides NixOS and nix-darwin service modules for declarative deployments.
+
 ## [0.1.64] - 2026-08-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ cargo install otelite
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/planetf1/otelite/releases/latest/download/otelite-installer.sh | sh
 ```
 
+**Nix:**
+
+```bash
+nix profile install github:planetf1/otelite
+```
+
+Packages, development shells, and NixOS/nix-darwin service modules are available; see [Nix support](nix/README.md).
+
 ## Quick Start
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,103 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1785627969,
+        "narHash": "sha256-4dtXQk/NMePegK/nWp5NSeuZKLATItOq61lpEvmXqGw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "427bf4bd9435fdf21321c8cc628c24efc14c0f7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785389976,
+        "narHash": "sha256-0tLW8Ff5yt8AH97jw4ZpFJ0OCJ122zIlgWGDmOfU/VU=",
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "rev": "15abb8c98f336cd8bd840d71059adebabe60bf04",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LnL7",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1785031560,
+        "narHash": "sha256-OmshNvn2vupOFpYinLUu+1Dnpu4n7Q5N3ggGVNHpkUI=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0e79af5e3d4dcfcd676ab5ba3f95d2e3352e078c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786420161,
+        "narHash": "sha256-PU4CY4GUCDFOoS67dGrc/fS6Y+d1cYZSh6nbgYqAAwE=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "3a646bd5daa3af78a78a1cb32329cb72d18fcae0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,99 @@
+{
+  description = "otelite - lightweight OpenTelemetry receiver and dashboard";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nix-darwin = {
+      url = "github:LnL7/nix-darwin";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs:
+    inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
+
+      flake =
+        let
+          nixosModule = import ./nix/nixos-module.nix;
+          darwinModule = import ./nix/darwin-module.nix;
+        in
+        {
+          nixosModules = {
+            default = nixosModule;
+            otelite = nixosModule;
+          };
+          darwinModules = {
+            default = darwinModule;
+            otelite = darwinModule;
+          };
+        };
+
+      perSystem =
+        { system, ... }:
+        let
+          pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ inputs.rust-overlay.overlays.default ];
+          };
+          lib = pkgs.lib;
+          rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+          otelite = pkgs.callPackage ./nix/package.nix { };
+          oteliteWorkspace = pkgs.callPackage ./nix/package.nix { workspaceCheck = true; };
+          packageOutputs = {
+            inherit otelite;
+            default = otelite;
+          };
+          appOutputs = {
+            otelite = {
+              type = "app";
+              program = pkgs.lib.getExe otelite;
+              meta.description = "run otelite";
+            };
+            default = {
+              type = "app";
+              program = pkgs.lib.getExe otelite;
+              meta.description = "run otelite";
+            };
+          };
+          checkOutputs = import ./nix/checks {
+            inherit
+              inputs
+              system
+              pkgs
+              lib
+              otelite
+              oteliteWorkspace
+              ;
+          };
+        in
+        {
+          packages = packageOutputs;
+
+          apps = appOutputs;
+
+          checks = checkOutputs;
+
+          formatter = pkgs.nixfmt-tree;
+
+          devShells.default = pkgs.mkShell {
+            packages = [
+              rustToolchain
+              pkgs.nixfmt-tree
+              pkgs.pkg-config
+            ];
+            buildInputs = [ pkgs.openssl ];
+          };
+        };
+    };
+}

--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,91 @@
+# Nix Support
+
+The flake provides source-built packages, development shells, checks, and
+service modules for NixOS and nix-darwin.
+
+## Packages
+
+Run or build Otelite for the current system:
+
+```bash
+nix run github:planetf1/otelite
+nix build github:planetf1/otelite#otelite
+```
+
+The source-built `otelite` package is available on `x86_64-linux`,
+`aarch64-linux`, and `aarch64-darwin` and is the default package on each system.
+
+## Development and Checks
+
+Clone the repository and run `nix develop` for the Rust toolchain and native
+build dependencies. Flake checks cover workspace formatting, Clippy, builds, tests,
+and service module evaluation on supported systems.
+
+## Services
+
+Both modules provision their default unprivileged account and run `otelite
+serve` in the foreground.
+
+Options use these defaults:
+
+| Option | NixOS | nix-darwin | Effect |
+| --- | --- | --- | --- |
+| `enable` | `false` | `false` | enable the service |
+| `package` | flake package | flake package | executable to run |
+| `address` | `127.0.0.1` | `127.0.0.1` | dashboard/API numeric IP only |
+| `port` | `3000` | `3000` | dashboard/API TCP port, 1-65535 |
+| `dataDir` | `/var/lib/otelite` | `/var/lib/otelite` | persistent SQLite state and home |
+| `user` / `group` | `otelite` | `_otelite` | unprivileged service identity |
+| `createUser` | default identity: `true`; custom: `false` | default identity: `true`; custom: `false` | provision the configured identity |
+| `uid` / `gid` | N/A | `536` / `536` | IDs for managed accounts only |
+| `logLevel` | `info` | `info` | `RUST_LOG` value |
+| `extraArgs` | `[]` | `[]` | literal unmanaged `serve` arguments |
+| `openFirewall` | `false` | N/A | open dashboard and OTLP TCP ports |
+
+`dataDir` must be an absolute, canonical, persistent path, not `/tmp`,
+`/var/tmp`, `/run`, `/var/run`, or the corresponding macOS `/private` aliases.
+NixOS uses `StateDirectory` for the default path and tmpfiles for custom paths;
+nix-darwin creates a managed account's home. Set `user` and `group` to use custom
+existing identities; `createUser` then defaults to false and the operator remains
+responsible for the account and state directory. nix-darwin checks the full
+directory-service search path for UID/GID conflicts before creating an account;
+its configurable defaults are project choices, not reserved macOS IDs.
+
+NixOS logs to journald (`journalctl -u otelite`). nix-darwin leaves launchd's
+stdout/stderr paths unset so macOS handles daemon output without privileged file
+operations inside service-owned state. `address` and `port` configure only the
+dashboard/API. The upstream OTLP gRPC and HTTP receivers always listen on all
+interfaces on TCP ports 4317 and 4318; `openFirewall` opens those fixed ports and
+the dashboard port only on NixOS.
+
+### NixOS
+
+```nix
+{
+  inputs.otelite.url = "github:planetf1/otelite";
+  imports = [ inputs.otelite.nixosModules.default ];
+
+  services.otelite = {
+    enable = true;
+    address = "127.0.0.1";
+    port = 3000;
+    openFirewall = false;
+  };
+}
+```
+
+### nix-darwin
+
+```nix
+{
+  inputs.otelite.url = "github:planetf1/otelite";
+  imports = [ inputs.otelite.darwinModules.default ];
+
+  services.otelite = {
+    enable = true;
+    # Set unused host IDs if the configurable project defaults collide.
+    uid = 536;
+    gid = 536;
+  };
+}
+```

--- a/nix/checks/darwin-module.nix
+++ b/nix/checks/darwin-module.nix
@@ -1,0 +1,250 @@
+{
+  inputs,
+  system,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  inherit (import ./lib.nix { inherit pkgs lib; }) mkEvalCheck evaluationFails;
+  darwinModuleCheck =
+    let
+      darwinModule = import ../darwin-module.nix;
+      evaluate =
+        module:
+        inputs.nix-darwin.lib.darwinSystem {
+          modules = [
+            darwinModule
+            {
+              system.stateVersion = 6;
+              nixpkgs.hostPlatform = system;
+            }
+            module
+          ];
+        };
+      default = (evaluate { services.otelite.enable = true; }).config;
+      defaultPlist = default.environment.launchDaemons."org.nixos.otelite.plist".text;
+      custom =
+        (evaluate {
+          users.groups.nginx = {
+            gid = 600;
+            description = "pre-existing group";
+          };
+          users.users.nginx = {
+            uid = 600;
+            gid = 600;
+            home = "/var/empty";
+            description = "pre-existing account";
+          };
+          services.otelite = {
+            enable = true;
+            user = "nginx";
+            group = "nginx";
+            dataDir = "/Library/Application Support/otelite-custom";
+          };
+        }).config;
+      managedCustom =
+        (evaluate {
+          services.otelite = {
+            enable = true;
+            createUser = true;
+            user = "_otelite_custom";
+            group = "_otelite_custom";
+            uid = 700;
+            gid = 701;
+          };
+        }).config;
+      ipv6 =
+        (evaluate {
+          services.otelite = {
+            enable = true;
+            address = "[::1]";
+            port = 4000;
+          };
+        }).config;
+    in
+    mkEvalCheck "otelite-darwin-module-eval" [
+      (builtins.isString default.system.build.toplevel.drvPath)
+      default.services.otelite.createUser
+      (default.users.users._otelite.uid == 536)
+      (default.users.groups._otelite.gid == 536)
+      (builtins.elem "_otelite" default.users.knownUsers)
+      (builtins.elem "_otelite" default.users.knownGroups)
+      (lib.hasInfix "uid %s is already used" default.system.checks.text)
+      (lib.hasInfix "gid %s is already used" default.system.checks.text)
+      (default.launchd.daemons.otelite.serviceConfig.StandardOutPath == null)
+      (default.launchd.daemons.otelite.serviceConfig.StandardErrorPath == null)
+      (!lib.hasInfix "<key>StandardOutPath</key>" defaultPlist)
+      (!lib.hasInfix "<key>StandardErrorPath</key>" defaultPlist)
+      (!lib.hasInfix "otelite.log" default.system.activationScripts.launchd.text)
+      (!lib.hasInfix "otelite.error.log" default.system.activationScripts.launchd.text)
+      (!lib.hasInfix "touch" default.system.activationScripts.launchd.text)
+      (!lib.hasInfix "chown" default.system.activationScripts.launchd.text)
+      (!lib.hasInfix "chmod" default.system.activationScripts.launchd.text)
+      (lib.hasInfix "/usr/bin/dscl /Search -search /Users UniqueID" default.system.checks.text)
+      (lib.hasInfix "/usr/bin/dscl /Search -search /Groups PrimaryGroupID" default.system.checks.text)
+      (lib.hasInfix "uid collision lookup failed" default.system.checks.text)
+      (lib.hasInfix "gid collision lookup failed" default.system.checks.text)
+      (!lib.hasInfix "otelite_uid_owner=$(dscl ." default.system.checks.text)
+      (!custom.services.otelite.createUser)
+      (builtins.hasAttr "nginx" custom.users.users)
+      (builtins.hasAttr "nginx" custom.users.groups)
+      (!builtins.hasAttr "_otelite" custom.users.users)
+      (!builtins.hasAttr "_otelite" custom.users.groups)
+      (custom.users.users.nginx.home == "/var/empty")
+      (custom.users.users.nginx.description == "pre-existing account")
+      (custom.users.groups.nginx.description == "pre-existing group")
+      (!builtins.elem "nginx" custom.users.knownUsers)
+      (!builtins.elem "nginx" custom.users.knownGroups)
+      (!lib.hasInfix "otelite_user='nginx'" custom.system.checks.text)
+      (!lib.hasInfix "/usr/bin/dscl /Search" custom.system.checks.text)
+      (custom.launchd.daemons.otelite.serviceConfig.StandardOutPath == null)
+      (custom.launchd.daemons.otelite.serviceConfig.StandardErrorPath == null)
+      (!lib.hasInfix "otelite.log" custom.system.activationScripts.launchd.text)
+      (!lib.hasInfix "otelite.error.log" custom.system.activationScripts.launchd.text)
+
+      managedCustom.services.otelite.createUser
+      (managedCustom.users.users._otelite_custom.uid == 700)
+      (managedCustom.users.users._otelite_custom.gid == 701)
+      managedCustom.users.users._otelite_custom.createHome
+      (managedCustom.users.groups._otelite_custom.gid == 701)
+      (builtins.elem "_otelite_custom" managedCustom.users.knownUsers)
+      (builtins.elem "_otelite_custom" managedCustom.users.knownGroups)
+      (default.launchd.daemons.otelite.environment.HOME == "/var/lib/otelite")
+      (
+        default.launchd.daemons.otelite.serviceConfig.ProgramArguments == [
+          (lib.getExe default.services.otelite.package)
+          "serve"
+          "--addr"
+          "127.0.0.1:3000"
+          "--storage-path"
+          "/var/lib/otelite"
+        ]
+      )
+      (
+        ipv6.launchd.daemons.otelite.serviceConfig.ProgramArguments == [
+          (lib.getExe ipv6.services.otelite.package)
+          "serve"
+          "--addr"
+          "[::1]:4000"
+          "--storage-path"
+          "/var/lib/otelite"
+        ]
+      )
+      default.launchd.daemons.otelite.serviceConfig.RunAtLoad
+      default.launchd.daemons.otelite.serviceConfig.KeepAlive
+      (evaluationFails (evaluate {
+        users.users.conflict = {
+          uid = 536;
+          gid = 600;
+        };
+        users.groups.conflict.gid = 600;
+        services.otelite.enable = true;
+      }))
+      (evaluationFails (evaluate {
+        users.users.conflict = {
+          uid = 600;
+          gid = 536;
+        };
+        users.groups.conflict.gid = 536;
+        services.otelite.enable = true;
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          address = "localhost";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          extraArgs = [ "--addr=0.0.0.0:3000" ];
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          extraArgs = [ "--storage-path" ];
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "relative/state";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/tmp/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/var/tmp/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/Library/../private/tmp/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/private/tmp/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/private/var/tmp/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/run/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/var/run/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/private/var/run/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          user = "root";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          group = "wheel";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          port = 0;
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          port = 4318;
+        };
+      }))
+    ];
+in
+darwinModuleCheck

--- a/nix/checks/default.nix
+++ b/nix/checks/default.nix
@@ -1,0 +1,23 @@
+args@{
+  pkgs,
+  otelite,
+  oteliteWorkspace,
+  ...
+}:
+{
+  inherit otelite;
+  otelite-workspace = oteliteWorkspace;
+  nixfmt = pkgs.runCommand "otelite-nixfmt-check" { nativeBuildInputs = [ pkgs.nixfmt-tree ]; } ''
+    cp -r ${../..} source
+    chmod -R u+w source
+    cd source
+    treefmt --ci
+    touch $out
+  '';
+}
+// pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isLinux {
+  nixos-module = import ./nixos-module.nix args;
+}
+// pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isDarwin {
+  darwin-module = import ./darwin-module.nix args;
+}

--- a/nix/checks/lib.nix
+++ b/nix/checks/lib.nix
@@ -1,0 +1,23 @@
+{ pkgs, lib }:
+{
+  mkEvalCheck =
+    name: assertions:
+    let
+      failures = lib.pipe assertions [
+        (lib.imap0 (
+          index: assertion: {
+            inherit assertion index;
+          }
+        ))
+        (builtins.filter (entry: !entry.assertion))
+        (map (entry: toString entry.index))
+      ];
+    in
+    assert lib.assertMsg (
+      failures == [ ]
+    ) "${name} failed assertions: ${lib.concatStringsSep ", " failures}";
+    pkgs.runCommand name { } "touch $out";
+
+  evaluationFails =
+    systemConfig: !(builtins.tryEval systemConfig.config.system.build.toplevel.drvPath).success;
+}

--- a/nix/checks/nixos-module.nix
+++ b/nix/checks/nixos-module.nix
@@ -1,0 +1,183 @@
+{
+  inputs,
+  system,
+  pkgs,
+  lib,
+  ...
+}:
+let
+  inherit (import ./lib.nix { inherit pkgs lib; }) mkEvalCheck evaluationFails;
+  nixosModuleCheck =
+    let
+      nixosModule = import ../nixos-module.nix;
+      evaluate =
+        module:
+        inputs.nixpkgs.lib.nixosSystem {
+          inherit system;
+          modules = [
+            nixosModule
+            {
+              system.stateVersion = "26.05";
+              fileSystems."/" = {
+                device = "/dev/disk";
+                fsType = "ext4";
+              };
+              boot.loader.grub.devices = [ "nodev" ];
+            }
+            module
+          ];
+        };
+      default = (evaluate { services.otelite.enable = true; }).config;
+      custom =
+        (evaluate {
+          users.groups.nginx = { };
+          users.users.nginx = {
+            isSystemUser = true;
+            group = "nginx";
+            home = "/var/empty";
+            description = "pre-existing account";
+          };
+          services.otelite = {
+            enable = true;
+            user = "nginx";
+            group = "nginx";
+            dataDir = "/srv/otelite";
+            openFirewall = true;
+          };
+        }).config;
+      managedCustom =
+        (evaluate {
+          services.otelite = {
+            enable = true;
+            createUser = true;
+            user = "otelite-custom";
+            group = "otelite-custom";
+          };
+        }).config;
+      ipv6 =
+        (evaluate {
+          services.otelite = {
+            enable = true;
+            address = "[::1]";
+            port = 4000;
+          };
+        }).config;
+    in
+    mkEvalCheck "otelite-nixos-module-eval" [
+      (builtins.isString default.system.build.toplevel.drvPath)
+      default.services.otelite.createUser
+      (default.users.users.otelite.home == "/var/lib/otelite")
+      (!default.users.users.otelite.createHome)
+      (default.systemd.services.otelite.serviceConfig.StateDirectory == "otelite")
+      (default.systemd.services.otelite.serviceConfig.StateDirectoryMode == "0750")
+      (default.systemd.tmpfiles.settings.otelite or { } == { })
+      (!custom.services.otelite.createUser)
+      (builtins.hasAttr "nginx" custom.users.users)
+      (builtins.hasAttr "nginx" custom.users.groups)
+      (!builtins.hasAttr "otelite" custom.users.users)
+      (!builtins.hasAttr "otelite" custom.users.groups)
+      (custom.users.users.nginx.home == "/var/empty")
+      (custom.users.users.nginx.description == "pre-existing account")
+      ((custom.systemd.services.otelite.serviceConfig.StateDirectory or null) == null)
+      (custom.systemd.tmpfiles.settings.otelite."/srv/otelite".d.user == "nginx")
+      (builtins.all (port: builtins.elem port custom.networking.firewall.allowedTCPPorts) [
+        3000
+        4317
+        4318
+      ])
+      managedCustom.services.otelite.createUser
+      (managedCustom.users.users."otelite-custom".group == "otelite-custom")
+      (builtins.hasAttr "otelite-custom" managedCustom.users.groups)
+      (lib.hasInfix "/bin/otelite\" \"serve\"" default.systemd.services.otelite.serviceConfig.ExecStart)
+      (!lib.hasInfix "\"start\"" default.systemd.services.otelite.serviceConfig.ExecStart)
+      (default.systemd.services.otelite.environment.HOME == "/var/lib/otelite")
+      default.systemd.services.otelite.serviceConfig.NoNewPrivileges
+      (lib.hasInfix "[::1]:4000" ipv6.systemd.services.otelite.serviceConfig.ExecStart)
+
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          address = "localhost";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          extraArgs = [ "--addr" ];
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          extraArgs = [ "--storage-path=/tmp/otelite" ];
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "relative/state";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/tmp/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/var/tmp/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/srv/../run/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/run/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/var/run/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          dataDir = "/home/otelite";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          user = "root";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          group = "wheel";
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          port = 0;
+        };
+      }))
+      (evaluationFails (evaluate {
+        services.otelite = {
+          enable = true;
+          port = 4317;
+        };
+      }))
+    ];
+in
+nixosModuleCheck

--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -1,0 +1,408 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.services.otelite;
+  dashboardSocket = "${cfg.address}:${toString cfg.port}";
+  executable = lib.getExe cfg.package;
+  dataDir = cfg.dataDir;
+  ipv4Octet = "(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])";
+  ipv6Match = builtins.match "[[]([0-9a-fA-F:]*)[]]" cfg.address;
+  isValidAddress =
+    builtins.match "${ipv4Octet}([.]${ipv4Octet}){3}" cfg.address != null
+    || (
+      ipv6Match != null
+      && (builtins.tryEval (
+        builtins.deepSeq (lib.network.ipv6.fromString (builtins.head ipv6Match)) true
+      )).success
+    );
+  managedArgs = [
+    "--addr"
+    "--storage-path"
+  ];
+  isManagedArg =
+    arg: builtins.any (managed: arg == managed || lib.hasPrefix "${managed}=" arg) managedArgs;
+  pathComponents = lib.filter (component: component != "") (lib.splitString "/" dataDir);
+  canonicalDataDir = "/${lib.concatStringsSep "/" pathComponents}";
+  volatileDataRoots = [
+    "/tmp"
+    "/private/tmp"
+    "/var/tmp"
+    "/private/var/tmp"
+    "/run"
+    "/var/run"
+    "/private/var/run"
+  ];
+  isVolatileDataDir = builtins.any (
+    root: canonicalDataDir == root || lib.hasPrefix "${root}/" canonicalDataDir
+  ) volatileDataRoots;
+  fixedReceiverWarning = ''
+    services.otelite: the otlp grpc and http receivers always bind all interfaces
+    on tcp ports 4317 and 4318; address only configures the dashboard and api.
+  '';
+  otherUsers = builtins.removeAttrs config.users.users [ cfg.user ];
+  otherGroups = builtins.removeAttrs config.users.groups [ cfg.group ];
+  uidConflicts = lib.attrNames (lib.filterAttrs (_: user: user.uid == cfg.uid) otherUsers);
+  gidConflicts = lib.attrNames (lib.filterAttrs (_: group: group.gid == cfg.gid) otherGroups);
+in
+{
+  options.services.otelite = {
+    enable = lib.mkEnableOption "the otelite telemetry receiver and dashboard";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix { };
+      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix { }";
+      description = "the otelite package to run.";
+    };
+
+    address = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      example = "0.0.0.0";
+      description = ''
+        numeric ip address for the dashboard and api. enclose an ipv6 address in
+        brackets. this does not configure the otlp receivers, which always bind
+        to all interfaces on tcp ports 4317 and 4318.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.ints.between 1 65535;
+      default = 3000;
+      example = 8080;
+      description = "nonzero tcp port for the dashboard and api.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/otelite";
+      example = "/Library/Application Support/otelite";
+      description = "absolute persistent directory containing otelite.db and the service home.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.strMatching "[_a-zA-Z][_a-zA-Z0-9-]*";
+      default = "_otelite";
+      description = ''
+        unprivileged account that runs the launchd daemon. custom accounts are
+        treated as operator-managed unless createUser is enabled.
+      '';
+    };
+
+    group = lib.mkOption {
+      type = lib.types.strMatching "[_a-zA-Z][_a-zA-Z0-9-]*";
+      default = "_otelite";
+      description = ''
+        group that owns otelite state. custom groups are treated as
+        operator-managed unless createUser is enabled.
+      '';
+    };
+
+    createUser = lib.mkOption {
+      type = lib.types.bool;
+      default = cfg.user == "_otelite" && cfg.group == "_otelite";
+      defaultText = lib.literalExpression ''
+        config.services.otelite.user == "_otelite"
+        && config.services.otelite.group == "_otelite"
+      '';
+      description = ''
+        whether nix-darwin creates and manages the configured user and group.
+        this defaults to true only for the default _otelite identity. when false,
+        the user and group must already exist and their attributes remain unchanged.
+      '';
+    };
+
+    uid = lib.mkOption {
+      type = lib.types.ints.between 502 2147483647;
+      default = 536;
+      description = ''
+        numeric id used only when createUser is true. 536 is a configurable
+        project default, not a reserved macos id. it must be unique in the
+        nix-darwin configuration and on the target host.
+      '';
+    };
+
+    gid = lib.mkOption {
+      type = lib.types.ints.between 502 2147483647;
+      default = 536;
+      description = ''
+        numeric id used only when createUser is true. 536 is a configurable
+        project default, not a reserved macos id. it must be unique in the
+        nix-darwin configuration and on the target host.
+      '';
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "trace"
+        "debug"
+        "info"
+        "warn"
+        "error"
+      ];
+      default = "info";
+      example = "debug";
+      description = "rust log filter exported to the daemon as RUST_LOG.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "--log-format=json" ];
+      description = ''
+        additional arguments passed to otelite after managed serve arguments.
+        each item is one literal launchd argument without shell expansion.
+        --addr and --storage-path are managed here and cannot be overridden.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = isValidAddress;
+        message = "services.otelite.address must be a numeric ipv4 address or bracketed ipv6 address";
+      }
+      {
+        assertion = lib.hasPrefix "/" dataDir;
+        message = "services.otelite.dataDir must be an absolute path";
+      }
+      {
+        assertion = dataDir != "/";
+        message = "services.otelite.dataDir must not be the filesystem root";
+      }
+      {
+        assertion =
+          dataDir == canonicalDataDir
+          && !builtins.any (
+            component:
+            builtins.elem component [
+              "."
+              ".."
+            ]
+          ) pathComponents;
+        message = "services.otelite.dataDir must be a canonical absolute path without . or .. components";
+      }
+      {
+        assertion = !isVolatileDataDir;
+        message = "services.otelite.dataDir must be persistent and must not be under a temporary or runtime directory";
+      }
+      {
+        assertion = cfg.user != "root";
+        message = "services.otelite.user must be an unprivileged account";
+      }
+      {
+        assertion =
+          !builtins.elem cfg.group [
+            "root"
+            "wheel"
+          ];
+        message = "services.otelite.group must be an unprivileged group";
+      }
+      {
+        assertion =
+          !builtins.elem cfg.port [
+            4317
+            4318
+          ];
+        message = "services.otelite.port must not conflict with fixed otlp ports 4317 or 4318";
+      }
+      {
+        assertion = !builtins.any isManagedArg cfg.extraArgs;
+        message = "services.otelite.extraArgs must not override --addr or --storage-path";
+      }
+      {
+        assertion = !cfg.createUser || uidConflicts == [ ];
+        message = "services.otelite.uid conflicts with configured user(s): ${lib.concatStringsSep ", " uidConflicts}";
+      }
+      {
+        assertion = !cfg.createUser || gidConflicts == [ ];
+        message = "services.otelite.gid conflicts with configured group(s): ${lib.concatStringsSep ", " gidConflicts}";
+      }
+    ];
+
+    warnings = [ fixedReceiverWarning ];
+
+    # nix-darwin otherwise warns and skips an account whose on-host id differs,
+    # leaving launchd configured with an unusable identity.
+    system.checks.text = lib.mkIf cfg.createUser (
+      lib.mkAfter ''
+        otelite_user=${lib.escapeShellArg cfg.user}
+        otelite_group=${lib.escapeShellArg cfg.group}
+        otelite_uid=${toString cfg.uid}
+        otelite_gid=${toString cfg.gid}
+
+        otelite_parse_id_owners() {
+          local expected_attribute="$1"
+          local expected_id="$2"
+
+          /usr/bin/awk -v attribute="$expected_attribute" -v id="$expected_id" '
+            NF {
+              if (
+                NF != 4 || $2 != attribute || $3 != "=" ||
+                $4 !~ /^[0-9]+$/ || $4 != id
+              ) exit 2
+              print $1
+              count++
+            }
+            END { if (count != 1) exit 2 }
+          '
+        }
+        # end otelite_parse_id_owners
+
+        if ! user_results=$(/usr/bin/dscl /Search -search /Users RecordName "$otelite_user" 2>&1); then
+          printf >&2 'services.otelite: directory-service user lookup failed: %s\n' "$user_results"
+          exit 2
+        fi
+        if [[ -n "$user_results" ]]; then
+          printf '%s\n' "$user_results" | /usr/bin/awk -v name="$otelite_user" '
+            NF {
+              if ($1 != name) exit 2
+              count++
+            }
+            END { if (count != 1) exit 2 }
+          ' >/dev/null || {
+            printf >&2 'services.otelite: ambiguous directory-service result for user %s\n' "$otelite_user"
+            exit 2
+          }
+          if ! existing_uid_record=$(/usr/bin/dscl /Search -read "/Users/$otelite_user" UniqueID 2>&1); then
+            printf >&2 'services.otelite: directory-service uid lookup failed: %s\n' "$existing_uid_record"
+            exit 2
+          fi
+          existing_uid=$(printf '%s\n' "$existing_uid_record" | /usr/bin/awk '
+            $1 == "UniqueID:" && NF == 2 { print $2; count++ }
+            END { if (count != 1) exit 2 }
+          ') || {
+            printf >&2 'services.otelite: ambiguous uid result for user %s\n' "$otelite_user"
+            exit 2
+          }
+          if [[ ! "$existing_uid" =~ ^[0-9]+$ || "$existing_uid" -ne "$otelite_uid" ]]; then
+            printf >&2 'services.otelite: existing user %s has uid %s, expected %s\n' \
+              "$otelite_user" "$existing_uid" "$otelite_uid"
+            exit 2
+          fi
+        fi
+
+        if ! uid_results=$(/usr/bin/dscl /Search -search /Users UniqueID "$otelite_uid" 2>&1); then
+          printf >&2 'services.otelite: directory-service uid collision lookup failed: %s\n' "$uid_results"
+          exit 2
+        fi
+        if [[ -n "$uid_results" ]]; then
+          uid_owners=$(printf '%s\n' "$uid_results" | otelite_parse_id_owners UniqueID "$otelite_uid") || {
+            printf >&2 'services.otelite: ambiguous directory-service uid result for %s\n' "$otelite_uid"
+            exit 2
+          }
+          while IFS= read -r uid_owner; do
+            if [[ "$uid_owner" != "$otelite_user" ]]; then
+              printf >&2 'services.otelite: uid %s is already used by user %s\n' \
+                "$otelite_uid" "$uid_owner"
+              exit 2
+            fi
+          done <<< "$uid_owners"
+        fi
+
+        if ! group_results=$(/usr/bin/dscl /Search -search /Groups RecordName "$otelite_group" 2>&1); then
+          printf >&2 'services.otelite: directory-service group lookup failed: %s\n' "$group_results"
+          exit 2
+        fi
+        if [[ -n "$group_results" ]]; then
+          printf '%s\n' "$group_results" | /usr/bin/awk -v name="$otelite_group" '
+            NF {
+              if ($1 != name) exit 2
+              count++
+            }
+            END { if (count != 1) exit 2 }
+          ' >/dev/null || {
+            printf >&2 'services.otelite: ambiguous directory-service result for group %s\n' "$otelite_group"
+            exit 2
+          }
+          if ! existing_gid_record=$(/usr/bin/dscl /Search -read "/Groups/$otelite_group" PrimaryGroupID 2>&1); then
+            printf >&2 'services.otelite: directory-service gid lookup failed: %s\n' "$existing_gid_record"
+            exit 2
+          fi
+          existing_gid=$(printf '%s\n' "$existing_gid_record" | /usr/bin/awk '
+            $1 == "PrimaryGroupID:" && NF == 2 { print $2; count++ }
+            END { if (count != 1) exit 2 }
+          ') || {
+            printf >&2 'services.otelite: ambiguous gid result for group %s\n' "$otelite_group"
+            exit 2
+          }
+          if [[ ! "$existing_gid" =~ ^[0-9]+$ || "$existing_gid" -ne "$otelite_gid" ]]; then
+            printf >&2 'services.otelite: existing group %s has gid %s, expected %s\n' \
+              "$otelite_group" "$existing_gid" "$otelite_gid"
+            exit 2
+          fi
+        fi
+
+        if ! gid_results=$(/usr/bin/dscl /Search -search /Groups PrimaryGroupID "$otelite_gid" 2>&1); then
+          printf >&2 'services.otelite: directory-service gid collision lookup failed: %s\n' "$gid_results"
+          exit 2
+        fi
+        if [[ -n "$gid_results" ]]; then
+          gid_owners=$(printf '%s\n' "$gid_results" | otelite_parse_id_owners PrimaryGroupID "$otelite_gid") || {
+            printf >&2 'services.otelite: ambiguous directory-service gid result for %s\n' "$otelite_gid"
+            exit 2
+          }
+          while IFS= read -r gid_owner; do
+            if [[ "$gid_owner" != "$otelite_group" ]]; then
+              printf >&2 'services.otelite: gid %s is already used by group %s\n' \
+                "$otelite_gid" "$gid_owner"
+              exit 2
+            fi
+          done <<< "$gid_owners"
+        fi
+      ''
+    );
+
+    users.knownUsers = lib.optional cfg.createUser cfg.user;
+    users.knownGroups = lib.optional cfg.createUser cfg.group;
+    users.users = lib.mkIf cfg.createUser {
+      ${cfg.user} = {
+        uid = cfg.uid;
+        gid = cfg.gid;
+        home = cfg.dataDir;
+        createHome = true;
+        isHidden = true;
+        shell = "/usr/bin/false";
+        description = "otelite service account";
+      };
+    };
+    users.groups = lib.mkIf cfg.createUser {
+      ${cfg.group} = {
+        gid = cfg.gid;
+        description = "otelite service group";
+      };
+    };
+
+    launchd.daemons.otelite = {
+      environment = {
+        HOME = dataDir;
+        RUST_LOG = cfg.logLevel;
+      };
+      serviceConfig = {
+        ProgramArguments = [
+          executable
+          "serve"
+          "--addr"
+          dashboardSocket
+          "--storage-path"
+          dataDir
+        ]
+        ++ cfg.extraArgs;
+        RunAtLoad = true;
+        KeepAlive = true;
+        WorkingDirectory = dataDir;
+        ProcessType = "Background";
+        ThrottleInterval = 5;
+        UserName = cfg.user;
+        GroupName = cfg.group;
+        # launchd property lists store this value in decimal: 23 is octal 0027.
+        Umask = 23;
+      };
+    };
+  };
+}

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -1,0 +1,304 @@
+{
+  config,
+  lib,
+  pkgs,
+  utils,
+  ...
+}:
+let
+  cfg = config.services.otelite;
+  dataDir = cfg.dataDir;
+  dashboardSocket = "${cfg.address}:${toString cfg.port}";
+  executable = lib.getExe cfg.package;
+  ipv4Octet = "(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])";
+  ipv6Match = builtins.match "[[]([0-9a-fA-F:]*)[]]" cfg.address;
+  isValidAddress =
+    builtins.match "${ipv4Octet}([.]${ipv4Octet}){3}" cfg.address != null
+    || (
+      ipv6Match != null
+      && (builtins.tryEval (
+        builtins.deepSeq (lib.network.ipv6.fromString (builtins.head ipv6Match)) true
+      )).success
+    );
+  managedArgs = [
+    "--addr"
+    "--storage-path"
+  ];
+  isManagedArg =
+    arg: builtins.any (managed: arg == managed || lib.hasPrefix "${managed}=" arg) managedArgs;
+  pathComponents = lib.filter (component: component != "") (lib.splitString "/" dataDir);
+  canonicalDataDir = "/${lib.concatStringsSep "/" pathComponents}";
+  volatileDataRoots = [
+    "/tmp"
+    "/var/tmp"
+    "/run"
+    "/var/run"
+  ];
+  isVolatileDataDir = builtins.any (
+    root: canonicalDataDir == root || lib.hasPrefix "${root}/" canonicalDataDir
+  ) volatileDataRoots;
+  isHomeDataDir =
+    dataDir == "/home"
+    || lib.hasPrefix "/home/" dataDir
+    || dataDir == "/root"
+    || lib.hasPrefix "/root/" dataDir
+    || dataDir == "/run/user"
+    || lib.hasPrefix "/run/user/" dataDir;
+  fixedReceiverWarning = ''
+    services.otelite: the otlp grpc and http receivers always bind all interfaces
+    on tcp ports 4317 and 4318; address only configures the dashboard and api.
+  '';
+  usesDefaultStateDirectory = dataDir == "/var/lib/otelite";
+in
+{
+  options.services.otelite = {
+    enable = lib.mkEnableOption "the otelite telemetry receiver and dashboard";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = pkgs.callPackage ./package.nix { };
+      defaultText = lib.literalExpression "pkgs.callPackage ./package.nix { }";
+      description = "the otelite package to run.";
+    };
+
+    address = lib.mkOption {
+      type = lib.types.str;
+      default = "127.0.0.1";
+      example = "0.0.0.0";
+      description = ''
+        numeric ip address for the dashboard and api. enclose an ipv6 address in
+        brackets. this does not configure the otlp receivers, which always bind
+        to all interfaces on tcp ports 4317 and 4318.
+      '';
+    };
+
+    port = lib.mkOption {
+      type = lib.types.ints.between 1 65535;
+      default = 3000;
+      example = 8080;
+      description = "tcp port for the dashboard and api.";
+    };
+
+    dataDir = lib.mkOption {
+      type = lib.types.str;
+      default = "/var/lib/otelite";
+      example = "/srv/otelite";
+      description = "absolute runtime directory containing otelite.db and the service home.";
+    };
+
+    user = lib.mkOption {
+      type = lib.types.strMatching "[_a-zA-Z][_a-zA-Z0-9-]*";
+      default = "otelite";
+      description = ''
+        unprivileged account that runs otelite. custom accounts are treated as
+        operator-managed unless createUser is enabled.
+      '';
+    };
+
+    group = lib.mkOption {
+      type = lib.types.strMatching "[_a-zA-Z][_a-zA-Z0-9-]*";
+      default = "otelite";
+      description = ''
+        group that owns otelite state. custom groups are treated as
+        operator-managed unless createUser is enabled.
+      '';
+    };
+
+    createUser = lib.mkOption {
+      type = lib.types.bool;
+      default = cfg.user == "otelite" && cfg.group == "otelite";
+      defaultText = lib.literalExpression ''
+        config.services.otelite.user == "otelite"
+        && config.services.otelite.group == "otelite"
+      '';
+      description = ''
+        whether to create and manage the configured user and group. this defaults
+        to true only for the default otelite identity. when false, the user and
+        group must already exist and the module leaves their attributes unchanged.
+      '';
+    };
+
+    logLevel = lib.mkOption {
+      type = lib.types.enum [
+        "trace"
+        "debug"
+        "info"
+        "warn"
+        "error"
+      ];
+      default = "info";
+      example = "debug";
+      description = "rust log filter exported to the service as RUST_LOG.";
+    };
+
+    extraArgs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "--log-format=json" ];
+      description = ''
+        additional arguments passed to otelite after managed serve arguments.
+        each item is one literal argument without shell expansion. --addr and
+        --storage-path are managed by this module and cannot be overridden.
+      '';
+    };
+
+    openFirewall = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        open the dashboard port and fixed otlp tcp ports 4317 and 4318. the
+        dashboard remains unreachable remotely when address is loopback; the
+        otlp receivers always listen on all interfaces.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = isValidAddress;
+        message = "services.otelite.address must be a numeric ipv4 address or bracketed ipv6 address";
+      }
+      {
+        assertion = lib.hasPrefix "/" dataDir;
+        message = "services.otelite.dataDir must be an absolute path";
+      }
+      {
+        assertion = dataDir != "/";
+        message = "services.otelite.dataDir must not be the filesystem root";
+      }
+      {
+        assertion =
+          dataDir == canonicalDataDir
+          && !builtins.any (
+            component:
+            builtins.elem component [
+              "."
+              ".."
+            ]
+          ) pathComponents;
+        message = "services.otelite.dataDir must be a canonical absolute path without . or .. components";
+      }
+      {
+        assertion = !isVolatileDataDir;
+        message = "services.otelite.dataDir must be persistent and must not be under /tmp, /var/tmp, /run, or /var/run";
+      }
+      {
+        assertion = !isHomeDataDir;
+        message = "services.otelite.dataDir must not be under /home, /root, or /run/user";
+      }
+      {
+        assertion = cfg.user != "root";
+        message = "services.otelite.user must be an unprivileged account";
+      }
+      {
+        assertion =
+          !builtins.elem cfg.group [
+            "root"
+            "wheel"
+          ];
+        message = "services.otelite.group must be an unprivileged group";
+      }
+      {
+        assertion =
+          !builtins.elem cfg.port [
+            4317
+            4318
+          ];
+        message = "services.otelite.port must not conflict with fixed otlp ports 4317 or 4318";
+      }
+      {
+        assertion = !builtins.any isManagedArg cfg.extraArgs;
+        message = "services.otelite.extraArgs must not override --addr or --storage-path";
+      }
+    ];
+
+    warnings = [ fixedReceiverWarning ];
+
+    users.groups = lib.mkIf cfg.createUser { ${cfg.group} = { }; };
+    users.users = lib.mkIf cfg.createUser {
+      ${cfg.user} = {
+        isSystemUser = true;
+        group = cfg.group;
+        home = dataDir;
+        description = "otelite service account";
+      };
+    };
+
+    systemd.tmpfiles.settings.otelite = lib.mkIf (!usesDefaultStateDirectory) {
+      ${dataDir}.d = {
+        mode = "0750";
+        user = cfg.user;
+        group = cfg.group;
+      };
+    };
+
+    networking.firewall.allowedTCPPorts = lib.mkIf cfg.openFirewall (
+      lib.unique [
+        cfg.port
+        4317
+        4318
+      ]
+    );
+
+    systemd.services.otelite = {
+      description = "otelite telemetry receiver and dashboard";
+      wantedBy = [ "multi-user.target" ];
+      wants = [ "network-online.target" ];
+      after = [ "network-online.target" ];
+      environment = {
+        HOME = dataDir;
+        RUST_LOG = cfg.logLevel;
+      };
+      unitConfig.RequiresMountsFor = [ dataDir ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = utils.escapeSystemdExecArgs (
+          [
+            executable
+            "serve"
+            "--addr"
+            dashboardSocket
+            "--storage-path"
+            dataDir
+          ]
+          ++ cfg.extraArgs
+        );
+        User = cfg.user;
+        Group = cfg.group;
+        WorkingDirectory = dataDir;
+        StateDirectory = lib.mkIf usesDefaultStateDirectory "otelite";
+        StateDirectoryMode = lib.mkIf usesDefaultStateDirectory "0750";
+        Restart = "on-failure";
+        RestartSec = "5s";
+        StandardOutput = "journal";
+        StandardError = "journal";
+        UMask = "0027";
+
+        AmbientCapabilities = "";
+        CapabilityBoundingSet = "";
+        LockPersonality = true;
+        NoNewPrivileges = true;
+        PrivateDevices = true;
+        PrivateTmp = true;
+        ProtectClock = true;
+        ProtectControlGroups = true;
+        ProtectHome = true;
+        ProtectHostname = true;
+        ProtectKernelLogs = true;
+        ProtectKernelModules = true;
+        ProtectKernelTunables = true;
+        ProtectSystem = "strict";
+        ReadWritePaths = [ dataDir ];
+        RemoveIPC = true;
+        RestrictAddressFamilies = [
+          "AF_UNIX"
+          "AF_INET"
+          "AF_INET6"
+        ];
+        RestrictNamespaces = true;
+        RestrictRealtime = true;
+      };
+    };
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,168 @@
+{
+  lib,
+  clippy,
+  fetchurl,
+  openssl,
+  pkg-config,
+  rustPlatform,
+  rustfmt,
+  stdenv,
+  workspaceCheck ? false,
+}:
+let
+  root = ../.;
+  rootString = toString root;
+  workspace = builtins.fromTOML (builtins.readFile ../Cargo.toml);
+  swaggerUi = fetchurl {
+    url = "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.12.zip";
+    hash = "sha256-HK4z/JI+1yq8BTBJveYXv9bpN/sXru7bn/8g5mf2B/I=";
+  };
+  src = lib.cleanSourceWith {
+    name = "otelite-source";
+    src = root;
+    filter =
+      path: type:
+      let
+        pathString = toString path;
+        relative = lib.removePrefix "${rootString}/" pathString;
+        topLevel = builtins.head (lib.splitString "/" relative);
+        name = baseNameOf path;
+        excludedDirectory =
+          type == "directory"
+          && builtins.elem name [
+            ".cache"
+            ".direnv"
+            ".git"
+            "build"
+            "coverage"
+            "debug"
+            "dist"
+            "release"
+            "target"
+          ];
+      in
+      lib.cleanSourceFilter path type
+      && (
+        pathString == rootString
+        || builtins.elem topLevel [
+          "Cargo.lock"
+          "Cargo.toml"
+          "LICENSE"
+          "README.md"
+          "clippy.toml"
+          "crates"
+          "rustfmt.toml"
+        ]
+      )
+      && !excludedDirectory
+      && !(name == "result" || lib.hasPrefix "result-" name)
+      && !lib.hasSuffix ".swp" name
+      && !lib.hasSuffix "~" name;
+  };
+in
+rustPlatform.buildRustPackage {
+  pname = if workspaceCheck then "otelite-workspace-check" else "otelite";
+  version = workspace.workspace.package.version;
+
+  inherit src;
+  cargoLock.lockFile = ../Cargo.lock;
+
+  # cargoInstallHook copies the binaries captured after cargoBuildHook; it does
+  # not run cargo install or consume cargoInstallFlags.
+  cargoBuildFlags =
+    if workspaceCheck then
+      [
+        "--workspace"
+        "--all-features"
+      ]
+    else
+      [
+        "-p"
+        "otelite"
+        "--bin"
+        "otelite"
+        "--all-features"
+      ];
+  cargoTestFlags =
+    if workspaceCheck then
+      [
+        "--workspace"
+        "--all-features"
+      ]
+    else
+      [
+        "-p"
+        "otelite"
+        "--all-features"
+      ];
+  doCheck = true;
+  checkType = "debug";
+  dontUseCargoParallelTests = true;
+  preBuild = ''
+    install -m 0644 ${swaggerUi} "$TMPDIR/swagger-ui.zip"
+    export SWAGGER_UI_DOWNLOAD_URL="file:$TMPDIR/swagger-ui.zip"
+  '';
+  preCheck = ''
+    install -m 0644 ${swaggerUi} "$TMPDIR/swagger-ui.zip"
+    export SWAGGER_UI_DOWNLOAD_URL="file:$TMPDIR/swagger-ui.zip"
+    export HOME="$TMPDIR/home"
+    mkdir -p "$HOME"
+  ''
+  + lib.optionalString workspaceCheck ''
+    cargo fmt --all -- --check
+    cargo clippy \
+      --target ${stdenv.hostPlatform.rust.rustcTarget} \
+      --offline \
+      --workspace \
+      --all-targets \
+      --all-features \
+      -- -D warnings
+    cargo build \
+      --target ${stdenv.hostPlatform.rust.rustcTarget} \
+      --offline \
+      --workspace \
+      --all-features
+  '';
+
+  nativeBuildInputs = [
+    pkg-config
+  ]
+  ++ lib.optionals workspaceCheck [
+    clippy
+    rustfmt
+  ];
+  buildInputs = [ openssl ];
+
+  env = {
+    OTELITE_GIT_SHA = "nix";
+    SOURCE_DATE_EPOCH = "1";
+    SWAGGER_UI_DOWNLOAD_URL = "file:${swaggerUi}";
+  };
+
+  postInstall = ''
+    test -x "$out/bin/otelite"
+    install -Dm644 LICENSE "$out/share/licenses/otelite/LICENSE"
+  '';
+
+  doInstallCheck = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+  installCheckPhase = ''
+    runHook preInstallCheck
+    "$out/bin/otelite" --version | grep -F "${workspace.workspace.package.version} (nix)"
+    "$out/bin/otelite" --help | grep -F "Lightweight OpenTelemetry receiver and dashboard"
+    "$out/bin/otelite" serve --help | grep -F -- "--storage-path"
+    runHook postInstallCheck
+  '';
+
+  meta = {
+    description = "lightweight OpenTelemetry receiver and dashboard for local development";
+    homepage = workspace.workspace.package.homepage;
+    changelog = "${workspace.workspace.package.repository}/blob/v${workspace.workspace.package.version}/CHANGELOG.md";
+    license = lib.licenses.asl20;
+    mainProgram = "otelite";
+    platforms = [
+      "x86_64-linux"
+      "aarch64-linux"
+      "aarch64-darwin"
+    ];
+  };
+}


### PR DESCRIPTION
# Pull Request

## Summary
Add first-class Nix support for building, running, developing, and deploying Otelite. The new flake provides source-built packages, a reproducible development shell, automated checks, and service modules for NixOS and nix-darwin on supported Linux and Apple Silicon systems.

## Changes
<!-- List of key changes -->
- Add source-built `otelite` package and app outputs for `x86_64-linux`, `aarch64-linux`, and `aarch64-darwin`.
- Add NixOS and nix-darwin service modules with unprivileged account management, persistent state handling, configurable service options, and platform-native systemd or launchd integration.
- Add a reproducible development shell and flake checks covering Nix formatting, Rust formatting, Clippy, workspace builds and tests, package installation, and service-module evaluation.
- Add a dedicated GitHub Actions workflow that runs `nix flake check` when relevant files change.
- Document Nix installation, development, service configuration, ports, logging, state management, and supported platforms in the README and changelog.


## Motivation
Nix users previously had no repository-maintained way to install, run, or deploy Otelite reproducibly. They had to use an imperative installer, maintain downstream packaging, and manually configure systemd or launchd services.

This change provides a supported Nix-native workflow for local use, development, and declarative service deployment while keeping Otelite unprivileged and its SQLite state persistent.


## Type of Change
<!-- Mark relevant options with an 'x' -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [x] Test improvements
- [x] CI/CD changes
- [x] Dependency updates

## Testing
<!-- How changes were tested -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed
- [x] All tests passing locally

The following command passes locally on `x86_64-linux`:

```bash
nix flake check --print-build-logs
```

This validates:

- Nix formatting
- The source-built Otelite package and installation checks
- Rust formatting, Clippy with warnings denied, workspace builds, and workspace tests
- NixOS module evaluation across valid and invalid configurations
- Flake packages, apps, modules, formatter, and development-shell outputs

The nix-darwin module and `aarch64-darwin` package cannot be built or fully evaluated on the local Linux host and still require validation on macOS.

**Test Coverage**:
- Current coverage: Not measured by this change
- Coverage change: Not applicable; no Rust application behavior was changed

## Breaking Changes
<!-- List any breaking changes and migration guide -->
- [x] No breaking changes
- [ ] Breaking changes documented below

**Breaking Changes**:
<!-- If applicable, describe breaking changes and migration path -->
None. Nix support is additive and existing installation and deployment methods remain unchanged.

## Documentation
<!-- Documentation updates -->
- [x] Code comments updated
- [x] README updated
- [x] CHANGELOG updated
- [ ] Architecture docs updated
- [ ] API docs updated
- [ ] No documentation needed

## Related Issues
<!-- Link related issues -->
Fixes https://github.com/planetf1/otelite/issues/122

## Checklist
<!-- Verify all items before submitting -->
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Comments added for complex code
- [x] Documentation updated
- [x] No new warnings generated
- [x] Tests added for new functionality
- [x] All tests passing
- [ ] Coverage threshold met (≥80%)
- [ ] Pre-commit hooks passing
- [x] No secrets or credentials in code
- [x] Breaking changes documented
- [x] CHANGELOG updated (if applicable)

## Screenshots
<!-- If applicable, add screenshots for UI changes -->
Not applicable; this change does not modify the UI.


## Additional Context
<!-- Any other relevant information -->
The service modules configure the dashboard and API address and port. Otelite's OTLP gRPC and HTTP receivers retain their upstream behavior and listen on TCP ports `4317` and `4318` on all interfaces.

The NixOS module can optionally open the dashboard and OTLP TCP ports, but firewall changes remain explicit and disabled by default. Both modules default to an unprivileged service identity and validate persistent state-directory configuration. The nix-darwin module exposes configurable UID and GID values so operators can avoid conflicts with existing local accounts.

The flake locks nixpkgs, flake-parts, nix-darwin, and the Rust overlay to make package builds and development environments reproducible.

## Reviewer Notes
Please focus review on:

- Service account creation and ownership behavior in the NixOS and nix-darwin modules
- State-directory validation and persistence guarantees
- systemd and launchd hardening and lifecycle configuration
- Firewall behavior and the distinction between dashboard/API and the currently fixed OTLP receiver ports
- Whether Otelite's configurable OTLP gRPC and HTTP bind addresses and ports should be exposed by the service modules now or addressed in a follow-up
- Cross-platform package inputs and flake output structure
- Whether the documented module defaults are appropriate for upstream adoption

---

**By submitting this PR, I confirm that my contributions are made under the Apache 2.0 license.**
