### PR TITLE
Per-PR changelog entry files — stop the changelog clash treadmill

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -48,7 +48,7 @@
 <!-- Documentation updates -->
 - [ ] Code comments updated
 - [ ] README updated
-- [ ] CHANGELOG updated
+- [ ] Changelog entry added: `changelog/<PR-number>.md`
 - [ ] Architecture docs updated
 - [ ] API docs updated
 - [ ] No documentation needed
@@ -71,7 +71,7 @@ Refs #
 - [ ] Pre-commit hooks passing
 - [ ] No secrets or credentials in code
 - [ ] Breaking changes documented
-- [ ] CHANGELOG updated (if applicable)
+- [ ] Changelog entry added: `changelog/<PR-number>.md` (see CONTRIBUTING → Changelog Entry)
 
 ## Screenshots
 <!-- If applicable, add screenshots for UI changes -->

--- a/.github/workflows/bump-and-tag.yml
+++ b/.github/workflows/bump-and-tag.yml
@@ -96,7 +96,7 @@ jobs:
         env:
           RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
-          git add Cargo.toml Cargo.lock CHANGELOG.md
+          git add Cargo.toml Cargo.lock CHANGELOG.md changelog/
           git commit -m "chore: release v${{ steps.bump.outputs.new }}"
           git tag "v${{ steps.bump.outputs.new }}"
           git push "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" main "v${{ steps.bump.outputs.new }}"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,50 @@
+name: Changelog entry
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  contents: read
+
+jobs:
+  entry:
+    name: Changelog Entry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Check the PR ships release notes
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          set -euo pipefail
+          base=$(git merge-base origin/main HEAD)
+          changed=$(git diff --name-only "$base" HEAD)
+
+          entry=$(printf '%s\n' "$changed" | grep -E '^changelog/[^/]+\.md$' | head -1 || true)
+          if [[ -n "$entry" ]]; then
+            if git show "HEAD:$entry" | grep -qE '^- '; then
+              echo "ok: $entry carries the release notes"
+              exit 0
+            fi
+            echo "error: $entry exists but has no bullet lines ('- ...')."
+            echo "Add at least one note, e.g. under '### Added' — or for pure"
+            echo "plumbing, an '### Internal' line. See CONTRIBUTING.md → Changelog Entry."
+            exit 1
+          fi
+
+          if printf '%s\n' "$changed" | grep -qx 'CHANGELOG.md'; then
+            echo "ok: CHANGELOG.md edited directly (maintainer flow)"
+            exit 0
+          fi
+
+          echo "error: this PR has no changelog entry."
+          echo "Create changelog/${PR_NUMBER:-<PR-number>}.md in your branch (start from"
+          echo "changelog/.template.md) with one bullet per user-visible change — or, for"
+          echo "pure plumbing, an '### Internal' note. See CONTRIBUTING.md → Changelog"
+          echo "Entry. The release workflow merges entry files into CHANGELOG.md; do not"
+          echo "edit CHANGELOG.md itself."
+          exit 1

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -13,26 +13,44 @@ on:
       - rustfmt.toml
       - clippy.toml
       - .github/workflows/nix.yml
+  # No paths filter on PRs: 'Flake Check' is a required check, and a
+  # required check that never runs blocks the merge. All PRs run this
+  # workflow; the expensive flake check self-skips when the flake inputs
+  # are untouched (a skipped required check does not block merges).
   pull_request:
     branches: [main, develop]
-    paths:
-      - flake.nix
-      - flake.lock
-      - nix/**
-      - Cargo.toml
-      - Cargo.lock
-      - rust-toolchain.toml
-      - rustfmt.toml
-      - clippy.toml
-      - .github/workflows/nix.yml
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Flake Inputs Changed
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.filter.outputs.changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect flake-relevant changes
+        id: filter
+        run: |
+          base=$(git merge-base origin/"${GITHUB_BASE_REF}" HEAD)
+          if git diff --name-only "$base" HEAD | grep -qE '^(flake\.(nix|lock)|nix/|Cargo\.(toml|lock)|rust-toolchain\.toml|rustfmt\.toml|clippy\.toml|\.github/workflows/nix\.yml)$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
   nix-check:
     name: Flake Check
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,19 +155,29 @@ changes, CI/release plumbing, dependency bumps with no behaviour change.
   per [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Flag breaking changes prominently.
 
-**Workflow**:
+**Workflow (per-PR entry files)**:
 
-1. While working on an issue, append entries under `## [Unreleased]` in `CHANGELOG.md`.
-2. At release time, the bump-and-tag CI workflow runs `scripts/rotate-changelog.sh`
-   which rotates `[Unreleased]` → `[X.Y.Z] - YYYY-MM-DD` and prepends a fresh empty
-   `[Unreleased]` block. The script **fails the release** if `[Unreleased]` is empty.
-3. For pure-plumbing pushes with no user impact, add an `### Internal` bullet
-   (e.g. "CI workflow tweak — no user-visible change"). This satisfies the gate
-   without inventing fake user-facing copy.
-4. If the bump fails because `[Unreleased]` was empty, add the missing bullet and
+1. While working on a PR, add `changelog/<PR-number>.md` (start from
+   `changelog/.template.md`) with the entry bullets. Do not edit
+   `CHANGELOG.md` — it is the release-generated record, and concurrent
+   edits to it are what used to make open PRs clash on every release
+   rotation.
+2. At release time, the bump-and-tag CI workflow runs
+   `scripts/rotate-changelog.sh`, which merges any `[Unreleased]` bullets
+   and every `changelog/*.md` entry into `[X.Y.Z] - YYYY-MM-DD` (canonical
+   section order: Added, Changed, Fixed, Removed, Internal) and deletes the
+   consumed entry files. The script **fails the release** if neither source
+   has at least one bullet.
+3. Bullets may still be appended under `## [Unreleased]` directly for
+   changes made on main itself; both sources merge into the release section.
+4. For pure-plumbing pushes with no user impact, add an `### Internal`
+   bullet (entry file or `[Unreleased]`). This satisfies the gate without
+   inventing fake user-facing copy.
+5. If the bump fails because no notes were found, add the missing entry and
    push — the workflow retries automatically on the next push to main.
 
-You can dry-run the rotation locally:
+Test the script: `scripts/rotate-changelog.sh --selftest`.
+Dry-run the rotation locally:
 
 ```bash
 scripts/rotate-changelog.sh 0.1.99 2026-05-15  # writes to CHANGELOG.md — git restore after

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,23 @@ If the count is the same as before and you added production code, you missed tes
 
 **Run tests after writing them.** Don't just add test functions — run `cargo test -p <crate>` and confirm they appear in the output and pass.
 
+### Test isolation — test data and test ports only
+
+- Tests never touch the developer's real otelite data (`~/.otelite/data`) or
+  the running daemon. Every spawned `serve`/`start` process gets a `tempfile`
+  data dir (`OTELITE_DATA_DIR` / `--storage-path`).
+- Tests never bind or probe the standard ports (OTLP 4317/4318, or any fixed
+  port). Every port a test process listens on is ephemeral (a `free_port()`
+  helper), passed through `--addr` / `OTELITE_OTLP_GRPC_PORT` /
+  `OTELITE_OTLP_HTTP_PORT` so both the spawned process and any discovery
+  assert agree on it. Fixed-port tests race with the dev daemon and with
+  parallel test binaries (observed CI failures 2026-09-04).
+- The UI stays runnable for testing on a test port with test data:
+  `otelite serve --addr 127.0.0.1:<free-port> --storage-path
+  <tempdir>/otelite.db` (plus the OTLP env overrides). Anything that
+  hardcodes a default port or data path in a way that prevents this is a
+  bug, not a test limitation.
+
 ## Picking What to Work On
 
 - **type:bug** before **type:feature** at the same priority

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,7 @@ Ensure your PR:
 - [ ] Has a clear, descriptive title
 - [ ] References related issues (e.g., "Fixes #123")
 - [ ] Includes a summary of changes in the description
+- [ ] Includes a changelog entry: `changelog/<PR-number>.md` (see below)
 
 ### PR Template
 
@@ -187,8 +188,31 @@ Refs #456
 - [ ] Tests added/updated
 - [ ] Documentation updated
 - [ ] Breaking changes documented
-- [ ] Changelog updated (if applicable)
+- [ ] Changelog entry added: `changelog/<PR-number>.md`
 ```
+
+### Changelog Entry
+
+Ship your release notes as a separate entry file — **do not edit
+`CHANGELOG.md`**:
+
+1. Create `changelog/<PR-number>.md` in your branch (start from
+   `changelog/.template.md`), e.g. `changelog/145.md`.
+2. Write one bullet per user-visible change, phrased as what the user can
+   now do (or no longer has to work around). Group bullets under
+   `### Added` / `### Changed` / `### Fixed` / `### Removed` /
+   `### Internal`; a file with no heading defaults to Added.
+3. The release workflow merges entry files into the next release section of
+   `CHANGELOG.md` and deletes them.
+
+Why not edit `CHANGELOG.md` directly? Every push to main rotates the
+changelog (a new release is cut), so a PR holding a `CHANGELOG.md` hunk
+conflicts with every release that lands while it is open — and with any
+other open PR editing the same section. Each PR owning its own entry file
+removes the clash entirely.
+
+Pure refactors, internal test changes and CI plumbing need no entry unless
+you want an `### Internal` note.
 
 ### Review Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,6 +211,10 @@ conflicts with every release that lands while it is open — and with any
 other open PR editing the same section. Each PR owning its own entry file
 removes the clash entirely.
 
+The PR template pre-checklists this, and the `Changelog Entry` CI check on
+every PR fails if neither an entry file (with at least one bullet) nor a
+direct `CHANGELOG.md` edit (maintainer flow) is present.
+
 Pure refactors, internal test changes and CI plumbing need no entry unless
 you want an `### Internal` note.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,6 +2159,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "comfy-table",
+ "crossterm 0.29.0",
  "csv",
  "minus",
  "mockito",

--- a/changelog/.template.md
+++ b/changelog/.template.md
@@ -1,0 +1,13 @@
+# Copy to changelog/<PR-number>.md in your branch, then fill in.
+#
+# One bullet per user-visible change, phrased as what the user can now do
+# (or no longer has to work around). Group bullets under one of:
+#   ### Added  ### Changed  ### Fixed  ### Removed  ### Internal
+# A file with no heading at all defaults to Added.
+#
+# The release workflow merges this file into the next release section of
+# CHANGELOG.md and deletes the file — do not edit CHANGELOG.md yourself.
+
+### Added
+
+- <one line describing what the user can now do>

--- a/changelog/185.md
+++ b/changelog/185.md
@@ -1,0 +1,15 @@
+### Added
+
+- Per-PR changelog entry files: PRs now ship their release notes as
+  `changelog/<PR-number>.md` instead of editing `CHANGELOG.md`, which ends
+  the changelog conflicts between open PRs and every release rotation. The
+  release workflow merges entry files into the next release section
+  (canonical section order) and deletes them; a new `Changelog Entry` CI
+  check on PRs enforces that notes ship with the change.
+
+### Internal
+
+- `scripts/rotate-changelog.sh` gains `--selftest` (five cases) and the
+  per-PR entry-file merge; unknown section headings fail loudly.
+- The PR template checklist now points at the entry file, and CONTRIBUTING
+  documents the flow.

--- a/changelog/185.md
+++ b/changelog/185.md
@@ -13,3 +13,10 @@
   per-PR entry-file merge; unknown section headings fail loudly.
 - The PR template checklist now points at the entry file, and CONTRIBUTING
   documents the flow.
+- `nix.yml` runs on every PR (Flake Check is a required check and a
+  never-running required check blocks merges); the flake check itself now
+  self-skips when no flake input changed.
+- Service-discovery integration tests run on ephemeral OTLP ports instead
+  of the standard 4317/4318 — parallel test binaries (or a real daemon)
+  holding the standard ports made the throwaway daemons die mid-test
+  (flaky CI failures 2026-09-04).

--- a/changelog/185.md
+++ b/changelog/185.md
@@ -13,6 +13,9 @@
   reports no usable size (a pty without a winsize). Tables now only fit to
   the terminal when a real width is available; piped and sized output is
   unchanged.
+- The daemon now flushes its buffered log lines to the rotating log file on
+  clean shutdown (SIGTERM); previously, lines the non-blocking appender had
+  not written yet were lost on exit.
 
 ### Internal
 

--- a/changelog/185.md
+++ b/changelog/185.md
@@ -30,3 +30,6 @@
   of the standard 4317/4318 — parallel test binaries (or a real daemon)
   holding the standard ports made the throwaway daemons die mid-test
   (flaky CI failures 2026-09-04).
+- The rotating-log test's failure message now includes the spawned serve's
+  `/proc/<pid>/limits`, open file descriptors, and data-dir file sizes —
+  environment forensics for the Nix build sandbox.

--- a/changelog/185.md
+++ b/changelog/185.md
@@ -7,6 +7,13 @@
   (canonical section order) and deletes them; a new `Changelog Entry` CI
   check on PRs enforces that notes ship with the change.
 
+### Fixed
+
+- CLI tables no longer render one character per column when the terminal
+  reports no usable size (a pty without a winsize). Tables now only fit to
+  the terminal when a real width is available; piped and sized output is
+  unchanged.
+
 ### Internal
 
 - `scripts/rotate-changelog.sh` gains `--selftest` (five cases) and the

--- a/crates/otelite/Cargo.toml
+++ b/crates/otelite/Cargo.toml
@@ -25,6 +25,7 @@ path = "src/lib.rs"
 [dependencies]
 clap = { workspace = true, features = ["env"] }
 comfy-table = "7.1"
+crossterm = "0.29"
 minus = { version = "5.6", features = ["static_output", "search"] }
 terminal_size = "0.4"
 reqwest = { workspace = true }

--- a/crates/otelite/src/commands/agents.rs
+++ b/crates/otelite/src/commands/agents.rs
@@ -3,8 +3,9 @@
 
 use crate::commands::usage::{fetch_pricing, parse_time_range};
 use crate::error::{Error, Result};
+use crate::output::pretty::fit_to_terminal;
 use clap::Args;
-use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
+use comfy_table::{presets::UTF8_FULL, Table};
 use otelite_core::api::AgentRollupResponse;
 use otelite_storage::StorageBackend;
 use std::sync::Arc;
@@ -93,17 +94,15 @@ fn display_agents(response: &AgentRollupResponse) {
 
     println!("\nAgents:\n");
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_header(vec![
-            "agent",
-            "sessions",
-            "cost",
-            "tokens",
-            "tool calls",
-            "retries",
-        ]);
+    table.load_preset(UTF8_FULL).set_header(vec![
+        "agent",
+        "sessions",
+        "cost",
+        "tokens",
+        "tool calls",
+        "retries",
+    ]);
+    fit_to_terminal(&mut table);
     for a in &response.agents {
         table.add_row(vec![
             a.agent.clone(),

--- a/crates/otelite/src/commands/cache.rs
+++ b/crates/otelite/src/commands/cache.rs
@@ -3,8 +3,9 @@
 
 use crate::commands::usage::{fetch_pricing, parse_time_range};
 use crate::error::{Error, Result};
+use crate::output::pretty::fit_to_terminal;
 use clap::Args;
-use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
+use comfy_table::{presets::UTF8_FULL, Table};
 use otelite_core::api::CacheEconomicsResponse;
 use otelite_storage::StorageBackend;
 use std::sync::Arc;
@@ -143,17 +144,15 @@ fn display_cache_economics(response: &CacheEconomicsResponse, show_series: bool,
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_header(vec![
-            "model",
-            "cache rd",
-            "cache wr",
-            "read:write",
-            "hit rate",
-            "est. savings",
-        ]);
+    table.load_preset(UTF8_FULL).set_header(vec![
+        "model",
+        "cache rd",
+        "cache wr",
+        "read:write",
+        "hit rate",
+        "est. savings",
+    ]);
+    fit_to_terminal(&mut table);
     for m in &response.models {
         table.add_row(vec![
             m.model.clone(),
@@ -177,8 +176,8 @@ fn display_cache_economics(response: &CacheEconomicsResponse, show_series: bool,
         );
         let mut st = Table::new();
         st.load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic)
             .set_header(vec!["bucket", "input", "cache rd", "cache wr", "hit rate"]);
+        fit_to_terminal(&mut st);
         for p in &response.series {
             st.add_row(vec![
                 fmt_ts(p.timestamp),

--- a/crates/otelite/src/commands/capabilities.rs
+++ b/crates/otelite/src/commands/capabilities.rs
@@ -10,8 +10,9 @@
 
 use crate::commands::usage::{now_ns, parse_cli_time, parse_time_range};
 use crate::error::{Error, Result};
+use crate::output::pretty::fit_to_terminal;
 use clap::Args;
-use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
+use comfy_table::{presets::UTF8_FULL, Table};
 use otelite_core::api::{
     GenAiCapabilityResponse, GenAiCorrelationProvenance, GenAiMetricCapability,
 };
@@ -130,7 +131,6 @@ fn display_capabilities(response: &GenAiCapabilityResponse) {
 /// evidence; this is a compact projection that keeps the same vocabulary.
 fn render_capabilities(response: &GenAiCapabilityResponse) -> String {
     use std::fmt::Write;
-    use std::io::IsTerminal;
     let mut out = String::new();
     let _ = writeln!(out, "\nTelemetry Capabilities");
     let _ = writeln!(
@@ -154,14 +154,7 @@ fn render_capabilities(response: &GenAiCapabilityResponse) -> String {
 
     let mut table = Table::new();
     table.load_preset(UTF8_FULL);
-    // Fit interactive terminals; leave piped and redirected output at natural
-    // width. comfy-table's Dynamic mode resolves the width via /dev/tty or a
-    // `tput` fallback when stdout is not a TTY — the fallback can yield a
-    // bogus width that wraps cell contents, breaking scripted consumers
-    // (and the render assertions below).
-    if std::io::stdout().is_terminal() {
-        table.set_content_arrangement(ContentArrangement::Dynamic);
-    }
+    fit_to_terminal(&mut table);
     table.set_header(vec![
         "Provider / Model",
         "Emitter",

--- a/crates/otelite/src/commands/llm.rs
+++ b/crates/otelite/src/commands/llm.rs
@@ -7,11 +7,10 @@
 use crate::commands::usage::parse_time_range;
 use crate::config::{Config, OutputFormat};
 use crate::error::{Error, Result};
+use crate::output::pretty::fit_to_terminal;
 use chrono::{DateTime, Local};
 use clap::Args;
-use comfy_table::{
-    modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Cell, Color, ContentArrangement, Table,
-};
+use comfy_table::{modifiers::UTF8_ROUND_CORNERS, presets::UTF8_FULL, Cell, Color, Table};
 use otelite_client::ApiClient;
 use otelite_core::api::TopSpan;
 
@@ -122,8 +121,8 @@ fn display_llm_table(spans: &[&TopSpan], since: &str) {
     let mut table = Table::new();
     table
         .load_preset(UTF8_FULL)
-        .apply_modifier(UTF8_ROUND_CORNERS)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+        .apply_modifier(UTF8_ROUND_CORNERS);
+    fit_to_terminal(&mut table);
     table.set_header(vec![
         Cell::new("Time").fg(Color::Cyan),
         Cell::new("Model").fg(Color::Cyan),

--- a/crates/otelite/src/commands/projects.rs
+++ b/crates/otelite/src/commands/projects.rs
@@ -3,8 +3,9 @@
 
 use crate::commands::usage::{fetch_pricing, parse_time_range};
 use crate::error::{Error, Result};
+use crate::output::pretty::fit_to_terminal;
 use clap::Args;
-use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
+use comfy_table::{presets::UTF8_FULL, Table};
 use otelite_core::api::ProjectRollupResponse;
 use otelite_storage::StorageBackend;
 use std::sync::Arc;
@@ -93,10 +94,14 @@ fn display_projects(response: &ProjectRollupResponse) {
 
     println!("\nProjects (codex/claude have no project label → unattributed):\n");
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_header(vec!["project", "sessions", "cost", "tokens", "top model"]);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL).set_header(vec![
+        "project",
+        "sessions",
+        "cost",
+        "tokens",
+        "top model",
+    ]);
     for p in &response.projects {
         let top = p
             .top_models

--- a/crates/otelite/src/commands/providers.rs
+++ b/crates/otelite/src/commands/providers.rs
@@ -3,8 +3,9 @@
 
 use crate::commands::usage::{fetch_pricing, parse_time_range};
 use crate::error::{Error, Result};
+use crate::output::pretty::fit_to_terminal;
 use clap::Args;
-use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
+use comfy_table::{presets::UTF8_FULL, Table};
 use otelite_core::api::ProviderMixResponse;
 use otelite_core::pricing::TokenUsage;
 use otelite_storage::StorageBackend;
@@ -115,13 +116,11 @@ fn display_provider_mix(response: &ProviderMixResponse, pricing_source: &str) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_header(vec![
-            "provider", "model", "tokens", "in", "out", "cache rd", "cache wr", "reason",
-            "sessions", "cost", "share",
-        ]);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL).set_header(vec![
+        "provider", "model", "tokens", "in", "out", "cache rd", "cache wr", "reason", "sessions",
+        "cost", "share",
+    ]);
 
     for provider in &response.providers {
         for (i, m) in provider.models.iter().enumerate() {

--- a/crates/otelite/src/commands/reasoning.rs
+++ b/crates/otelite/src/commands/reasoning.rs
@@ -3,8 +3,9 @@
 
 use crate::commands::usage::{fetch_pricing, parse_time_range};
 use crate::error::{Error, Result};
+use crate::output::pretty::fit_to_terminal;
 use clap::Args;
-use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
+use comfy_table::{presets::UTF8_FULL, Table};
 use otelite_core::api::ReasoningShareResponse;
 use otelite_storage::StorageBackend;
 use std::sync::Arc;
@@ -105,16 +106,14 @@ fn display_reasoning_share(response: &ReasoningShareResponse) {
         println!("  No token activity in the window.\n");
     } else {
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic)
-            .set_header(vec![
-                "model",
-                "reasoning",
-                "output",
-                "share",
-                "thinking cost",
-            ]);
+        fit_to_terminal(&mut table);
+        table.load_preset(UTF8_FULL).set_header(vec![
+            "model",
+            "reasoning",
+            "output",
+            "share",
+            "thinking cost",
+        ]);
         for m in &response.models {
             table.add_row(vec![
                 m.model.clone(),
@@ -133,8 +132,8 @@ fn display_reasoning_share(response: &ReasoningShareResponse) {
     if !response.effort.is_empty() {
         println!("By reasoning effort (codex):\n");
         let mut st = Table::new();
+        fit_to_terminal(&mut st);
         st.load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic)
             .set_header(vec!["effort", "calls", "reasoning tokens"]);
         for e in &response.effort {
             st.add_row(vec![

--- a/crates/otelite/src/commands/sessions.rs
+++ b/crates/otelite/src/commands/sessions.rs
@@ -3,8 +3,9 @@
 
 use crate::commands::usage::{fetch_pricing, parse_time_range, validate_since};
 use crate::error::{Error, Result};
+use crate::output::pretty::fit_to_terminal;
 use clap::{Args, Subcommand};
-use comfy_table::{presets::UTF8_FULL, ContentArrangement, Table};
+use comfy_table::{presets::UTF8_FULL, Table};
 use otelite_core::session_cost;
 use otelite_storage::StorageBackend;
 use std::sync::Arc;
@@ -167,9 +168,8 @@ fn display_context(resp: &otelite_core::api::SessionContextResponse) {
         resp.spans_total
     );
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    table.load_preset(UTF8_FULL);
+    fit_to_terminal(&mut table);
     table.set_header(vec!["time", "span", "model", "duration"]);
     for span in &resp.spans {
         table.add_row(vec![
@@ -182,9 +182,8 @@ fn display_context(resp: &otelite_core::api::SessionContextResponse) {
     println!("{table}");
     println!("\nLogs ({} shown of {}):", resp.logs.len(), resp.logs_total);
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    table.load_preset(UTF8_FULL);
+    fit_to_terminal(&mut table);
     table.set_header(vec!["time", "severity", "body"]);
     for log in &resp.logs {
         table.add_row(vec![
@@ -197,9 +196,8 @@ fn display_context(resp: &otelite_core::api::SessionContextResponse) {
     if !resp.metrics.is_empty() {
         println!("\nMetrics (aggregated):");
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic);
+        table.load_preset(UTF8_FULL);
+        fit_to_terminal(&mut table);
         table.set_header(vec!["name", "type", "count", "sum", "min", "max"]);
         for m in &resp.metrics {
             table.add_row(vec![
@@ -285,12 +283,10 @@ fn display_costs(response: &otelite_core::api::SessionCostResponse) {
 
     println!("\nSessions by cost ({}):\n", response.anomaly_rule);
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic)
-        .set_header(vec![
-            "session", "agent", "cost", "tokens", "duration", "anomaly",
-        ]);
+    table.load_preset(UTF8_FULL).set_header(vec![
+        "session", "agent", "cost", "tokens", "duration", "anomaly",
+    ]);
+    fit_to_terminal(&mut table);
     for s in &response.sessions {
         table.add_row(vec![
             s.session_id.clone(),

--- a/crates/otelite/src/commands/usage.rs
+++ b/crates/otelite/src/commands/usage.rs
@@ -1,8 +1,9 @@
 //! Token usage command for GenAI/LLM spans
 
 use crate::error::{Error, Result};
+use crate::output::pretty::fit_to_terminal;
 use clap::Args;
-use comfy_table::{presets::UTF8_FULL, Cell, Color, ContentArrangement, Table};
+use comfy_table::{presets::UTF8_FULL, Cell, Color, Table};
 use otelite_core::filters::GenAiFilters;
 use otelite_core::pricing::{PricingDatabase, TokenUsage};
 use otelite_storage::StorageBackend;
@@ -1555,9 +1556,8 @@ fn format_header(range: &str, start: Option<&str>, end: Option<&str>) -> String 
 
 fn display_summary(summary: &otelite_core::api::TokenUsageSummary) {
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("Metric").fg(Color::Cyan),
@@ -1601,9 +1601,8 @@ fn display_by_model(models: &[ModelRow]) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     // Rerouting columns are only meaningful when some identity shows them.
     let show_rerouting = models
@@ -1660,9 +1659,8 @@ fn display_by_system(systems: &[SystemRow]) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("System").fg(Color::Cyan),
@@ -1696,9 +1694,8 @@ fn display_top_spans(spans: &[otelite_core::api::TopSpan], n: usize) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("#").fg(Color::Cyan),
@@ -1738,9 +1735,8 @@ fn display_by_session(rows: &[SessionRow]) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("Session ID").fg(Color::Cyan),
@@ -1800,9 +1796,8 @@ fn display_latency_stats(stats: &[otelite_core::api::LatencyStats]) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("Model").fg(Color::Cyan),
@@ -1907,9 +1902,8 @@ fn display_latency_series(
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     let mut header: Vec<Cell> = vec![
         Cell::new("Bucket").fg(Color::Cyan),
@@ -1998,9 +1992,8 @@ fn display_latency_context(bins: &[otelite_core::api::LatencyByContextBin]) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("Context Bin").fg(Color::Cyan),
@@ -2088,9 +2081,8 @@ fn display_latency_percentiles<'a>(
                 continue;
             }
             let mut table = Table::new();
-            table
-                .load_preset(UTF8_FULL)
-                .set_content_arrangement(ContentArrangement::Dynamic);
+            fit_to_terminal(&mut table);
+            table.load_preset(UTF8_FULL);
             table.set_header(vec![
                 Cell::new("Bucket").fg(Color::Cyan),
                 Cell::new("Model").fg(Color::Cyan),
@@ -2151,9 +2143,8 @@ fn display_truncation_rate(rows: &[otelite_core::api::TruncationRateByModel]) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("Model").fg(Color::Cyan),
@@ -2192,9 +2183,8 @@ fn display_cache_hit_rate(rows: &[otelite_core::api::CacheHitRateByModel]) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("Model").fg(Color::Cyan),
@@ -2230,9 +2220,8 @@ fn display_cache_hit_rate(rows: &[otelite_core::api::CacheHitRateByModel]) {
 fn display_request_params(profile: &otelite_core::api::RequestParamProfile) {
     if !profile.temperature_buckets.is_empty() {
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic);
+        fit_to_terminal(&mut table);
+        table.load_preset(UTF8_FULL);
 
         table.set_header(vec![
             Cell::new("Temperature").fg(Color::Cyan),
@@ -2250,9 +2239,8 @@ fn display_request_params(profile: &otelite_core::api::RequestParamProfile) {
 
     if !profile.max_tokens_buckets.is_empty() {
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic);
+        fit_to_terminal(&mut table);
+        table.load_preset(UTF8_FULL);
 
         table.set_header(vec![
             Cell::new("max_tokens").fg(Color::Cyan),
@@ -2276,9 +2264,8 @@ fn display_conv_depth(depth: &otelite_core::api::ConversationDepthStats) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("Metric").fg(Color::Cyan),
@@ -2305,9 +2292,8 @@ fn display_tool_usage(rows: &[otelite_core::api::ToolUsage]) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("Tool").fg(Color::Cyan),
@@ -2350,9 +2336,8 @@ fn display_error_types(rows: &[otelite_core::api::ErrorTypeBreakdown]) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("Bucket").fg(Color::Red),
@@ -2383,9 +2368,8 @@ fn display_model_drift(rows: &[otelite_core::api::ModelDriftPair]) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("Requested Model").fg(Color::Cyan),
@@ -2417,9 +2401,8 @@ fn display_tool_approvals(stats: &otelite_core::api::ToolApprovalStats) {
     let reject_pct = stats.rejected as f64 / total as f64 * 100.0;
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Decision").fg(Color::Cyan),
         Cell::new("Count").fg(Color::Cyan),
@@ -2450,8 +2433,8 @@ fn display_tool_approvals(stats: &otelite_core::api::ToolApprovalStats) {
 
     if !stats.top_rejected.is_empty() {
         let mut t2 = Table::new();
-        t2.load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic);
+        fit_to_terminal(&mut t2);
+        t2.load_preset(UTF8_FULL);
         t2.set_header(vec![
             Cell::new("Tool").fg(Color::Cyan),
             Cell::new("Rejections").fg(Color::Cyan),
@@ -2471,9 +2454,8 @@ fn display_stop_reasons(rows: &[otelite_core::api::StopReasonCount]) {
     }
     let total: usize = rows.iter().map(|r| r.count).sum();
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Reason").fg(Color::Cyan),
         Cell::new("Count").fg(Color::Cyan),
@@ -2501,9 +2483,8 @@ fn display_context_split(rows: &[otelite_core::api::ContextTypeSplit]) {
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Context").fg(Color::Cyan),
         Cell::new("Calls").fg(Color::Cyan),
@@ -2535,9 +2516,8 @@ fn display_tool_errors(rows: &[otelite_core::api::ToolErrorEntry]) {
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Tool").fg(Color::Cyan),
         Cell::new("Error (truncated)").fg(Color::Cyan),
@@ -2559,9 +2539,8 @@ fn display_hour_of_day(buckets: &[otelite_core::api::HourOfDayBucket]) {
         .unwrap_or(1)
         .max(1);
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Hour (UTC)").fg(Color::Cyan),
         Cell::new("LLM calls").fg(Color::Cyan),
@@ -2588,9 +2567,8 @@ fn display_agent_roles(response: &otelite_core::api::AgentRolesResponse) {
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Role").fg(Color::Cyan),
         Cell::new("Sessions").fg(Color::Cyan),
@@ -2657,9 +2635,8 @@ fn display_calls_series(points: &[otelite_core::api::CallsSeriesPoint]) {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
 
     table.set_header(vec![
         Cell::new("Bucket").fg(Color::Cyan),
@@ -2685,9 +2662,8 @@ fn display_session_models(breakdown: &otelite_core::api::SessionModelBreakdown) 
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Session ID").fg(Color::Cyan),
         Cell::new("Model").fg(Color::Cyan),
@@ -2716,9 +2692,8 @@ fn display_speed_distribution(dist: &otelite_core::api::SpeedDistribution) {
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Speed / mode").fg(Color::Cyan),
         Cell::new("Model").fg(Color::Cyan),
@@ -2745,9 +2720,8 @@ fn display_effort_breakdown(resp: &otelite_core::api::EffortBreakdownResponse) {
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Effort").fg(Color::Cyan),
         Cell::new("Model").fg(Color::Cyan),
@@ -2785,9 +2759,8 @@ fn display_efficiency(stats: &otelite_core::api::EfficiencyStats) {
     }
     if !stats.by_agent.is_empty() {
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic);
+        fit_to_terminal(&mut table);
+        table.load_preset(UTF8_FULL);
         table.set_header(vec![
             Cell::new("Agent").fg(Color::Cyan),
             Cell::new("Tokens").fg(Color::Cyan),
@@ -2815,9 +2788,8 @@ fn display_reasoning_share(resp: &otelite_core::api::ReasoningShareResponse) {
     }
     if !resp.models.is_empty() {
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic);
+        fit_to_terminal(&mut table);
+        table.load_preset(UTF8_FULL);
         table.set_header(vec![
             Cell::new("Model").fg(Color::Cyan),
             Cell::new("Reasoning tok").fg(Color::Cyan),
@@ -2843,9 +2815,8 @@ fn display_reasoning_share(resp: &otelite_core::api::ReasoningShareResponse) {
     }
     if !resp.effort.is_empty() {
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic);
+        fit_to_terminal(&mut table);
+        table.load_preset(UTF8_FULL);
         table.set_header(vec![
             Cell::new("Effort level").fg(Color::Cyan),
             Cell::new("Reasoning tok").fg(Color::Cyan),
@@ -2875,9 +2846,8 @@ fn display_guardian(resp: &otelite_core::api::GuardianStatsResponse) {
     );
     {
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic);
+        fit_to_terminal(&mut table);
+        table.load_preset(UTF8_FULL);
         table.set_header(vec![
             Cell::new("Risk level").fg(Color::Cyan),
             Cell::new("Count").fg(Color::Cyan),
@@ -2894,9 +2864,8 @@ fn display_guardian(resp: &otelite_core::api::GuardianStatsResponse) {
     }
     if !resp.by_action.is_empty() {
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic);
+        fit_to_terminal(&mut table);
+        table.load_preset(UTF8_FULL);
         table.set_header(vec![
             Cell::new("Action").fg(Color::Cyan),
             Cell::new("Count").fg(Color::Cyan),
@@ -2925,9 +2894,8 @@ fn display_multi_agent(resp: &otelite_core::api::MultiAgentStatsResponse) {
     );
     if !resp.roles.is_empty() {
         let mut table = Table::new();
-        table
-            .load_preset(UTF8_FULL)
-            .set_content_arrangement(ContentArrangement::Dynamic);
+        fit_to_terminal(&mut table);
+        table.load_preset(UTF8_FULL);
         table.set_header(vec![
             Cell::new("Role").fg(Color::Cyan),
             Cell::new("Spawns").fg(Color::Cyan),
@@ -2952,9 +2920,8 @@ fn display_codex_ttft(resp: &otelite_core::api::CodexTtftResponse) {
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Model").fg(Color::Cyan),
         Cell::new("Count").fg(Color::Cyan),
@@ -2985,9 +2952,8 @@ fn display_codex_turns(resp: &otelite_core::api::CodexTurnBreakdownResponse) {
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Model").fg(Color::Cyan),
         Cell::new("Project").fg(Color::Cyan),
@@ -3018,9 +2984,8 @@ fn display_cross_tool_ttft(resp: &otelite_core::api::CrossToolTtftResponse) {
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Tool").fg(Color::Cyan),
         Cell::new("Model").fg(Color::Cyan),
@@ -3077,9 +3042,8 @@ fn display_hook_overhead(resp: &otelite_core::api::HookOverheadResponse) {
         resp.grand_total_ms / 1000.0,
     );
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Hook event").fg(Color::Cyan),
         Cell::new("Invocations").fg(Color::Cyan),
@@ -3103,9 +3067,8 @@ fn display_tool_failure_rates(resp: &otelite_core::api::ToolFailureRatesResponse
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Tool").fg(Color::Cyan),
         Cell::new("Total").fg(Color::Cyan),
@@ -3151,9 +3114,8 @@ fn display_daily_tool_mix(resp: &otelite_core::api::DailyToolMixResponse) {
         header.push(Cell::new(t.as_str()).fg(Color::Cyan));
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(header);
     for (day, by_tool) in &pivot {
         let total: u64 = by_tool.values().sum();
@@ -3178,9 +3140,8 @@ fn display_skill_activity(resp: &otelite_core::api::SkillActivityResponse) {
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Skill").fg(Color::Cyan),
         Cell::new("Invoke type").fg(Color::Cyan),
@@ -3220,9 +3181,8 @@ fn display_session_quality(resp: &otelite_core::api::SessionQualitySummary) {
         }
     };
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Grade").fg(Color::Cyan),
         Cell::new("Sessions").fg(Color::Cyan),
@@ -3258,9 +3218,8 @@ fn display_skill_outcomes(resp: &otelite_core::api::SkillOutcomesResponse) {
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Skill").fg(Color::Cyan),
         Cell::new("Sessions with").fg(Color::Cyan),
@@ -3293,9 +3252,8 @@ fn display_model_selection_heatmap(resp: &otelite_core::api::ModelSelectionHeatm
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Role").fg(Color::Cyan),
         Cell::new("Tool").fg(Color::Cyan),
@@ -3324,9 +3282,8 @@ fn display_recent_errors(resp: &otelite_core::api::RecentErrorsResponse) {
         return;
     }
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    fit_to_terminal(&mut table);
+    table.load_preset(UTF8_FULL);
     table.set_header(vec![
         Cell::new("Tool").fg(Color::Cyan),
         Cell::new("Time").fg(Color::Cyan),

--- a/crates/otelite/src/main.rs
+++ b/crates/otelite/src/main.rs
@@ -512,8 +512,12 @@ async fn run_cli() -> Result<()> {
     let env_filter =
         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level.to_string()));
 
-    // Configure output destination and format
-    if let Some(log_file) = &cli.log_file {
+    // Configure output destination and format. The non-blocking appender's
+    // guard is held for the process lifetime: dropping it at exit signals
+    // the worker to flush buffered lines, so a clean shutdown doesn't lose
+    // the tail of the log (the previous `mem::forget` skipped that final
+    // flush).
+    let _appender_guard = if let Some(log_file) = &cli.log_file {
         // Log to file with daily rotation
         let file_appender = tracing_appender::rolling::daily(
             log_file
@@ -523,7 +527,7 @@ async fn run_cli() -> Result<()> {
                 .file_name()
                 .unwrap_or_else(|| std::ffi::OsStr::new("otelite.log")),
         );
-        let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
+        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
         // Choose format based on --log-format flag
         if cli.log_format.to_lowercase() == "json" {
@@ -538,8 +542,7 @@ async fn run_cli() -> Result<()> {
                 .init();
         }
 
-        // Keep the guard alive by leaking it - this is intentional for the lifetime of the program
-        std::mem::forget(_guard);
+        Some(guard)
     } else {
         // Log to stderr (default)
         if cli.log_format.to_lowercase() == "json" {
@@ -553,7 +556,8 @@ async fn run_cli() -> Result<()> {
                 .with(fmt::layer())
                 .init();
         }
-    }
+        None
+    };
 
     // Build config from config file, then apply CLI args on top.
     // Precedence: CLI flags > OTELITE_ENDPOINT > config file > defaults.

--- a/crates/otelite/src/output/pretty.rs
+++ b/crates/otelite/src/output/pretty.rs
@@ -6,7 +6,27 @@ use comfy_table::{presets::UTF8_FULL, Cell, ContentArrangement, Table};
 use otelite_client::models::{LogEntry, MetricResponse, SpanEntry, TraceDetail, TraceEntry};
 use otelite_core::telemetry::{format_attribute_value, GenAiSpanInfo};
 use std::collections::HashMap;
-use std::io;
+use std::io::{self, IsTerminal};
+
+/// Fit a table to an interactive terminal when one is actually usable;
+/// otherwise leave it at natural width.
+///
+/// comfy-table's `Dynamic` arrangement trusts the terminal size crossterm
+/// reports, which has two failure modes: a pty without a winsize (observed
+/// in the Nix build sandbox, where test stdout is a pty reporting 0x0)
+/// renders the table one character per column, and the `tput` fallback can
+/// report a width for a non-tty stdout, wrapping piped output and breaking
+/// scripted consumers. Only fit when stdout is a terminal and a usable
+/// width resolves.
+pub fn fit_to_terminal(table: &mut Table) {
+    if io::stdout().is_terminal() {
+        if let Ok((width, _)) = crossterm::terminal::size() {
+            if width >= 40 {
+                table.set_content_arrangement(ContentArrangement::Dynamic);
+            }
+        }
+    }
+}
 
 /// A span node in the tree for display
 #[derive(Debug, Clone)]
@@ -62,9 +82,8 @@ pub fn print_logs_table(logs: &[LogEntry], config: &Config) -> io::Result<()> {
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    table.load_preset(UTF8_FULL);
+    fit_to_terminal(&mut table);
 
     // Add header (unless disabled)
     if !config.no_header {
@@ -169,9 +188,8 @@ pub fn print_traces_table(traces: &[TraceEntry], config: &Config) -> io::Result<
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    table.load_preset(UTF8_FULL);
+    fit_to_terminal(&mut table);
 
     // Add header (unless disabled)
     if !config.no_header {
@@ -330,9 +348,8 @@ pub fn print_metrics_table(metrics: &[MetricResponse], config: &Config) -> io::R
     }
 
     let mut table = Table::new();
-    table
-        .load_preset(UTF8_FULL)
-        .set_content_arrangement(ContentArrangement::Dynamic);
+    table.load_preset(UTF8_FULL);
+    fit_to_terminal(&mut table);
 
     // Add header (unless disabled)
     if !config.no_header {
@@ -452,6 +469,18 @@ mod tests {
             no_header: false,
             no_pager: true,
         }
+    }
+
+    #[test]
+    fn fit_to_terminal_leaves_natural_width_when_piped() {
+        // cargo pipes test stdout, so the helper must not switch the
+        // table to Dynamic (which would wrap piped output).
+        let mut table = Table::new();
+        fit_to_terminal(&mut table);
+        assert!(
+            matches!(table.content_arrangement(), ContentArrangement::Disabled),
+            "piped stdout must keep natural table width"
+        );
     }
 
     #[test]

--- a/crates/otelite/tests/service_discovery_test.rs
+++ b/crates/otelite/tests/service_discovery_test.rs
@@ -472,27 +472,36 @@ fn test_serve_writes_rotating_log_file() {
         .unwrap();
 
     wait_for_port(dashboard_port, Instant::now() + Duration::from_secs(15));
-    // Give the non-blocking appender a moment to flush the startup lines.
-    std::thread::sleep(Duration::from_secs(1));
 
-    // The rotating appender names its file otelite.log.YYYY-MM-DD.
-    let rotated = std::fs::read_dir(&data_dir)
-        .expect("data dir exists")
-        .filter_map(|e| e.ok())
-        .map(|e| e.file_name())
-        .find(|name| name.to_string_lossy().starts_with("otelite.log."));
-    assert!(
-        rotated.is_some(),
-        "expected a dated otelite.log.* file; data dir contents: {:?}",
-        std::fs::read_dir(&data_dir)
-            .map(|d| d.map(|e| e.unwrap().file_name()).collect::<Vec<_>>())
-            .unwrap_or_default()
-    );
-    let rotated_path = data_dir.join(rotated.unwrap());
-    assert!(
-        std::fs::metadata(&rotated_path).unwrap().len() > 0,
-        "the startup log lines must have been flushed"
-    );
+    // The rotating appender names its file otelite.log.YYYY-MM-DD. The
+    // non-blocking writer flushes from a background thread, so poll for a
+    // dated file with content instead of assuming a fixed delay — a 1-second
+    // sleep was not enough in the Nix build sandbox (observed 2026-09-04).
+    let deadline = Instant::now() + Duration::from_secs(15);
+    loop {
+        let ready = std::fs::read_dir(&data_dir)
+            .expect("data dir exists")
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name())
+            .find(|name| name.to_string_lossy().starts_with("otelite.log."))
+            .map(|name| {
+                std::fs::metadata(data_dir.join(name))
+                    .map(|m| m.len() > 0)
+                    .unwrap_or(false)
+            })
+            .unwrap_or(false);
+        if ready {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "expected a dated otelite.log.* file with flushed startup lines; data dir contents: {:?}",
+            std::fs::read_dir(&data_dir)
+                .map(|d| d.map(|e| e.unwrap().file_name()).collect::<Vec<_>>())
+                .unwrap_or_default()
+        );
+        std::thread::sleep(Duration::from_millis(200));
+    }
 
     nix::sys::signal::kill(
         Pid::from_raw(child.id() as i32),

--- a/crates/otelite/tests/service_discovery_test.rs
+++ b/crates/otelite/tests/service_discovery_test.rs
@@ -450,7 +450,6 @@ fn test_serve_exits_gracefully_on_sigterm() {
 fn test_serve_writes_rotating_log_file() {
     let temp = tempfile::TempDir::new().unwrap();
     let data_dir = temp.path().join("data");
-    let storage = data_dir.join("otelite.db");
     let dashboard_port = free_port();
     let grpc_port = free_port();
     let http_port = free_port();
@@ -469,7 +468,7 @@ fn test_serve_writes_rotating_log_file() {
             "--addr",
             &format!("127.0.0.1:{dashboard_port}"),
             "--storage-path",
-            &storage.to_string_lossy(),
+            &data_dir.to_string_lossy(),
             "--log-file",
             &data_dir.join("otelite.log").to_string_lossy(),
         ])
@@ -527,13 +526,35 @@ fn test_serve_writes_rotating_log_file() {
             .join(", ")
     };
     // Linux-only forensics for environment-specific failures (the Nix build
-    // sandbox): the child's resource limits and open file descriptors, so a
+    // sandbox): the child's resource limits, thread states (where is the
+    // log-appender worker blocked?), and open file descriptors, so a
     // 0-byte log file can say *why*.
     let proc_snapshot = |pid: u32| -> String {
         let mut s = String::new();
         let limits = format!("/proc/{pid}/limits");
         if let Ok(l) = std::fs::read_to_string(&limits) {
             s.push_str(&format!("--- {limits} ---\n{l}\n"));
+        }
+        if let Ok(status) = std::fs::read_to_string(format!("/proc/{pid}/status")) {
+            for line in status.lines() {
+                if line.starts_with("Name:")
+                    || line.starts_with("Threads:")
+                    || line.starts_with("Voluntary")
+                {
+                    s.push_str(&format!("{line}\n"));
+                }
+            }
+        }
+        let task_dir = format!("/proc/{pid}/task");
+        if let Ok(tasks) = std::fs::read_dir(&task_dir) {
+            for t in tasks.filter_map(|e| e.ok()) {
+                let tid = t.file_name().to_string_lossy().to_string();
+                let name =
+                    std::fs::read_to_string(format!("{task_dir}/{tid}/comm")).unwrap_or_default();
+                let wchan = std::fs::read_to_string(format!("{task_dir}/{tid}/wchan"))
+                    .unwrap_or_else(|_| "<running>".into());
+                s.push_str(&format!("thread {tid}: {name} wchan={wchan}\n"));
+            }
         }
         let fd_dir = format!("/proc/{pid}/fd");
         if let Ok(fds) = std::fs::read_dir(&fd_dir) {

--- a/crates/otelite/tests/service_discovery_test.rs
+++ b/crates/otelite/tests/service_discovery_test.rs
@@ -2,25 +2,17 @@
 //! file, which only `otelite start` writes. A service-managed or hand-run
 //! `serve` (no PID file) is discovered through its TCP listener instead.
 //!
-//! `serve` always owns OTLP port 4317, so the spawn-and-discover half only
-//! runs when 4317 is free (CI). When a real daemon holds 4317 — the common
-//! dev-machine state — the daemon itself is a no-PID-file listener (the
-//! launchd/service path never writes one), so discovery against it is
-//! asserted directly.
+//! The throwaway daemons run on ephemeral OTLP ports (via
+//! OTELITE_OTLP_GRPC_PORT / OTELITE_OTLP_HTTP_PORT), not the standard
+//! 4317/4318: nextest runs integration test binaries in parallel, so a
+//! sibling binary — or a real daemon on a dev machine — holding the
+//! standard ports would make a default-port `serve` die on its second bind
+//! and race the discovery assertions (observed CI failures 2026-09-04).
 
 use std::net::{TcpListener, TcpStream};
 use std::time::{Duration, Instant};
 
 use nix::unistd::Pid;
-
-/// Tests that spawn a throwaway `serve` on the standard OTLP port 4317 must
-/// not run concurrently: each probes 4317 first and spawns when it is free,
-/// so two racers can both spawn — one binds 4317 and the other test's
-/// `lsof` discovery then attributes the port to the *wrong* PID (observed CI
-/// failure 2026-09-04: assert_eq found-pid vs own-pid in the Coverage job,
-/// where `cargo test --tests` runs this file's tests in parallel threads).
-/// Hold this guard for the whole test, including spawn and teardown.
-static OTLP_PORT_MUTEX: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
 fn wait_for_port(port: u16, deadline: Instant) {
     loop {
@@ -56,44 +48,33 @@ fn wait_for_otelite_attribution(port: u16, deadline: Instant) {
 
 #[test]
 fn test_discovery_finds_serve_without_pid_file() {
-    let _port_guard = OTLP_PORT_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-
-    // Probe 4317: if something owns it, a daemon (or another test) is
-    // already in the no-PID-file state and the regression is asserted
-    // against it below. Otherwise we can spawn a throwaway serve.
-    let probe = TcpStream::connect((std::net::IpAddr::from([127, 0, 0, 1]), 4317));
-    if probe.is_ok() {
-        let found = otelite::commands::service::local_otelite_pid(4317)
-            .unwrap()
-            .expect("a listening daemon on 4317 must be discovered");
-        assert!(
-            nix::sys::signal::kill(Pid::from_raw(found as i32), None).is_ok(),
-            "discovered PID must be alive"
-        );
-        return;
-    }
-
     let temp = tempfile::TempDir::new().unwrap();
     let data_dir = temp.path().join("data");
     let storage = data_dir.join("otelite.db");
     let pid_file = data_dir.join("otelite.pid");
 
+    let dashboard_port = free_port();
+    let grpc_port = free_port();
+    let http_port = free_port();
+
     let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_otelite"))
         .args([
             "serve",
             "--addr",
-            "127.0.0.1:13999",
+            &format!("127.0.0.1:{dashboard_port}"),
             "--storage-path",
             &storage.to_string_lossy(),
         ])
         .env("OTELITE_DATA_DIR", data_dir.as_os_str())
+        .env("OTELITE_OTLP_GRPC_PORT", grpc_port.to_string())
+        .env("OTELITE_OTLP_HTTP_PORT", http_port.to_string())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .spawn()
         .unwrap();
     let pid = child.id();
 
-    wait_for_port(4317, Instant::now() + Duration::from_secs(15));
+    wait_for_port(grpc_port, Instant::now() + Duration::from_secs(15));
 
     // The regression itself: no PID file, yet the listener is discovered
     // and the PID matches the serve process.
@@ -101,7 +82,7 @@ fn test_discovery_finds_serve_without_pid_file() {
         !pid_file.exists(),
         "serve must not write a PID file (premise of #107)"
     );
-    let found = otelite::commands::service::local_otelite_pid(4317)
+    let found = otelite::commands::service::local_otelite_pid(grpc_port)
         .unwrap()
         .expect("listener discovery must find the serve process");
     assert_eq!(found, pid, "discovered PID must be the serve process");
@@ -112,14 +93,28 @@ fn test_discovery_finds_serve_without_pid_file() {
     let status_out = std::process::Command::new(env!("CARGO_BIN_EXE_otelite"))
         .arg("status")
         .env("OTELITE_DATA_DIR", data_dir.as_os_str())
+        .env("OTELITE_OTLP_GRPC_PORT", grpc_port.to_string())
+        .env("OTELITE_OTLP_HTTP_PORT", http_port.to_string())
         .output()
         .unwrap();
+    let status_text = String::from_utf8_lossy(&status_out.stdout);
+
+    // On a dev machine with a launchd-managed daemon, `status` reports
+    // that daemon first — intended product behaviour, and `stop` would
+    // then signal the *real* daemon. The discovery regression is already
+    // asserted directly above; only run the e2e half where `status`
+    // reports the throwaway (i.e. CI, no launchd daemon).
+    if status_text.contains("Running (launchd") {
+        let _ = child.kill();
+        let _ = child.wait();
+        return;
+    }
+
     assert!(
         status_out.status.success(),
         "status must succeed: {}",
         String::from_utf8_lossy(&status_out.stderr)
     );
-    let status_text = String::from_utf8_lossy(&status_out.stdout);
     assert!(
         status_text.contains("Status: Running"),
         "status output: {status_text}"
@@ -132,6 +127,8 @@ fn test_discovery_finds_serve_without_pid_file() {
     let stop_out = std::process::Command::new(env!("CARGO_BIN_EXE_otelite"))
         .arg("stop")
         .env("OTELITE_DATA_DIR", data_dir.as_os_str())
+        .env("OTELITE_OTLP_GRPC_PORT", grpc_port.to_string())
+        .env("OTELITE_OTLP_HTTP_PORT", http_port.to_string())
         .output()
         .unwrap();
     assert!(
@@ -156,7 +153,7 @@ fn test_discovery_finds_serve_without_pid_file() {
             },
         }
     }
-    let _ = TcpListener::bind("127.0.0.1:4317");
+    let _ = TcpListener::bind(format!("127.0.0.1:{grpc_port}"));
 }
 
 fn free_port() -> u16 {
@@ -174,46 +171,45 @@ fn free_port_held() -> (u16, TcpListener) {
 /// one, instead of leaving a PID file for a process that dies on bind.
 #[test]
 fn test_start_refuses_when_daemon_has_no_pid_file() {
-    // Shares 4317 with test_discovery_finds_serve_without_pid_file —
-    // serialize so the two throwaway serves can't race the bind.
-    let _port_guard = OTLP_PORT_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
-
-    let otelite_on_4317 = otelite::commands::service::local_otelite_pid(4317).unwrap();
+    let grpc_port = free_port();
+    let http_port = free_port();
 
     let temp = tempfile::TempDir::new().unwrap();
     let data_dir = temp.path().join("data");
 
-    // A throwaway serve so the test is self-contained on machines
-    // (CI) where no daemon holds 4317.
-    let mut throwaway = None;
+    // A throwaway serve on ephemeral OTLP ports, so the test is
+    // self-contained regardless of what else (a real daemon, a sibling
+    // test binary) runs on this machine.
+    let storage = data_dir.join("otelite.db");
     let dashboard_port = free_port();
-    if otelite_on_4317.is_none() {
-        let storage = data_dir.join("otelite.db");
-        let child = std::process::Command::new(env!("CARGO_BIN_EXE_otelite"))
-            .args([
-                "serve",
-                "--addr",
-                &format!("127.0.0.1:{dashboard_port}"),
-                "--storage-path",
-                &storage.to_string_lossy(),
-            ])
-            .env("OTELITE_DATA_DIR", data_dir.as_os_str())
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .spawn()
-            .unwrap();
-        wait_for_port(4317, Instant::now() + Duration::from_secs(15));
-        wait_for_otelite_attribution(4317, Instant::now() + Duration::from_secs(15));
-        throwaway = Some(child);
-    }
+    let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_otelite"))
+        .args([
+            "serve",
+            "--addr",
+            &format!("127.0.0.1:{dashboard_port}"),
+            "--storage-path",
+            &storage.to_string_lossy(),
+        ])
+        .env("OTELITE_DATA_DIR", data_dir.as_os_str())
+        .env("OTELITE_OTLP_GRPC_PORT", grpc_port.to_string())
+        .env("OTELITE_OTLP_HTTP_PORT", http_port.to_string())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .unwrap();
+    wait_for_port(grpc_port, Instant::now() + Duration::from_secs(15));
+    wait_for_otelite_attribution(grpc_port, Instant::now() + Duration::from_secs(15));
 
     // `start` from a different (empty) data dir: no PID file to trip
-    // on, only port discovery can find the daemon.
+    // on, only port discovery can find the daemon. It sees the same OTLP
+    // ports via the environment, so discovery targets the throwaway.
     let start_data_dir = temp.path().join("start-data");
     let start_port = free_port();
     let out = std::process::Command::new(env!("CARGO_BIN_EXE_otelite"))
         .args(["start", "--addr", &format!("127.0.0.1:{start_port}")])
         .env("OTELITE_DATA_DIR", start_data_dir.as_os_str())
+        .env("OTELITE_OTLP_GRPC_PORT", grpc_port.to_string())
+        .env("OTELITE_OTLP_HTTP_PORT", http_port.to_string())
         .output()
         .unwrap();
 
@@ -237,10 +233,8 @@ fn test_start_refuses_when_daemon_has_no_pid_file() {
         "a refused start must not leave a PID file"
     );
 
-    if let Some(mut child) = throwaway {
-        let _ = child.kill();
-        let _ = child.wait();
-    }
+    let _ = child.kill();
+    let _ = child.wait();
 }
 
 /// #M12 regression: when the spawned daemon dies immediately (its

--- a/crates/otelite/tests/service_discovery_test.rs
+++ b/crates/otelite/tests/service_discovery_test.rs
@@ -509,6 +509,49 @@ fn test_serve_writes_rotating_log_file() {
             .collect::<Vec<_>>()
             .join("\n")
     };
+    // File sizes, not just names: a 0-byte sqlite db next to a 0-byte log
+    // is a very different story from a healthy db next to a 0-byte log.
+    let dir_listing = |dir: &std::path::Path| -> String {
+        std::fs::read_dir(dir)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .map(|e| {
+                format!(
+                    "{} ({} bytes)",
+                    e.file_name().to_string_lossy(),
+                    e.metadata().map(|m| m.len()).unwrap_or(0)
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    // Linux-only forensics for environment-specific failures (the Nix build
+    // sandbox): the child's resource limits and open file descriptors, so a
+    // 0-byte log file can say *why*.
+    let proc_snapshot = |pid: u32| -> String {
+        let mut s = String::new();
+        let limits = format!("/proc/{pid}/limits");
+        if let Ok(l) = std::fs::read_to_string(&limits) {
+            s.push_str(&format!("--- {limits} ---\n{l}\n"));
+        }
+        let fd_dir = format!("/proc/{pid}/fd");
+        if let Ok(fds) = std::fs::read_dir(&fd_dir) {
+            for e in fds.filter_map(|e| e.ok()) {
+                if let Ok(link) = std::fs::read_link(e.path()) {
+                    s.push_str(&format!(
+                        "fd {} -> {}\n",
+                        e.file_name().to_string_lossy(),
+                        link.display()
+                    ));
+                }
+            }
+        }
+        if s.is_empty() {
+            s.push_str("(no /proc access — not Linux?)\n");
+        }
+        s
+    };
 
     // The rotating appender names its file otelite.log.YYYY-MM-DD (the M17
     // regression itself) and a background worker writes the lines into it.
@@ -533,6 +576,9 @@ fn test_serve_writes_rotating_log_file() {
         std::thread::sleep(Duration::from_millis(200));
     }
 
+    // Snapshot the child's environment while it is still alive.
+    let snapshot = proc_snapshot(child.id());
+
     nix::sys::signal::kill(
         Pid::from_raw(child.id() as i32),
         nix::sys::signal::Signal::SIGTERM,
@@ -552,9 +598,11 @@ fn test_serve_writes_rotating_log_file() {
     let final_len = log_len(&data_dir);
     assert!(
         final_len > 0,
-        "no log lines reached the dated file ({} bytes while running, {} bytes after clean shutdown); serve stderr:\n{}",
+        "no log lines reached the dated file ({} bytes while running, {} bytes after clean shutdown);\ndata dir: {};\nserve stderr:\n{};\n{}",
         live_len,
         final_len,
-        stderr_tail(&data_dir)
+        dir_listing(&data_dir),
+        stderr_tail(&data_dir),
+        snapshot
     );
 }

--- a/crates/otelite/tests/service_discovery_test.rs
+++ b/crates/otelite/tests/service_discovery_test.rs
@@ -443,7 +443,9 @@ fn test_serve_exits_gracefully_on_sigterm() {
 
 /// M17 regression: the daemon's log must go through the daily-rotating
 /// appender (`--log-file`), not an ever-growing plain file. A throwaway
-/// `serve` must produce a dated log file in its data dir.
+/// `serve` must produce a dated log file in its data dir, and the startup
+/// lines must actually reach it — either while the worker thread is running
+/// or via the final flush when the appender's guard drops on clean shutdown.
 #[test]
 fn test_serve_writes_rotating_log_file() {
     let temp = tempfile::TempDir::new().unwrap();
@@ -452,6 +454,14 @@ fn test_serve_writes_rotating_log_file() {
     let dashboard_port = free_port();
     let grpc_port = free_port();
     let http_port = free_port();
+
+    // Capture serve's stderr: with --log-file the tracing output goes to the
+    // log file, but panics and startup errors (e.g. the appender worker
+    // thread failing to spawn) land on stderr — exactly what a 0-byte log
+    // file in the Nix build sandbox needed to explain itself.
+    let stderr_path = data_dir.join("serve-stderr.log");
+    std::fs::create_dir_all(&data_dir).unwrap();
+    let stderr_file = std::fs::File::create(&stderr_path).unwrap();
 
     let mut child = std::process::Command::new(env!("CARGO_BIN_EXE_otelite"))
         .args([
@@ -467,38 +477,58 @@ fn test_serve_writes_rotating_log_file() {
         .env("OTELITE_OTLP_GRPC_PORT", grpc_port.to_string())
         .env("OTELITE_OTLP_HTTP_PORT", http_port.to_string())
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::from(stderr_file))
         .spawn()
         .unwrap();
 
     wait_for_port(dashboard_port, Instant::now() + Duration::from_secs(15));
 
-    // The rotating appender names its file otelite.log.YYYY-MM-DD. The
-    // non-blocking writer flushes from a background thread, so poll for a
-    // dated file with content instead of assuming a fixed delay — a 1-second
-    // sleep was not enough in the Nix build sandbox (observed 2026-09-04).
-    let deadline = Instant::now() + Duration::from_secs(15);
-    loop {
-        let ready = std::fs::read_dir(&data_dir)
-            .expect("data dir exists")
+    let dated_log = |dir: &std::path::Path| -> Option<std::path::PathBuf> {
+        std::fs::read_dir(dir)
+            .into_iter()
+            .flatten()
             .filter_map(|e| e.ok())
-            .map(|e| e.file_name())
-            .find(|name| name.to_string_lossy().starts_with("otelite.log."))
-            .map(|name| {
-                std::fs::metadata(data_dir.join(name))
-                    .map(|m| m.len() > 0)
+            .map(|e| e.path())
+            .find(|p| {
+                p.file_name()
+                    .map(|n| n.to_string_lossy().starts_with("otelite.log."))
                     .unwrap_or(false)
             })
-            .unwrap_or(false);
-        if ready {
+    };
+    let log_len = |dir: &std::path::Path| -> u64 {
+        dated_log(dir)
+            .and_then(|p| std::fs::metadata(p).ok())
+            .map(|m| m.len())
+            .unwrap_or(0)
+    };
+    let stderr_tail = |dir: &std::path::Path| -> String {
+        std::fs::read_to_string(dir.join("serve-stderr.log"))
+            .unwrap_or_default()
+            .lines()
+            .take(20)
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    // The rotating appender names its file otelite.log.YYYY-MM-DD (the M17
+    // regression itself) and a background worker writes the lines into it.
+    // The worker is normally fast, but a loaded build sandbox may starve it
+    // for seconds; poll for live content, then fall back to the shutdown
+    // flush (the appender guard drops on clean exit) before failing.
+    let mut live_len = 0u64;
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        live_len = log_len(&data_dir);
+        if live_len > 0 {
             break;
         }
         assert!(
-            Instant::now() < deadline,
-            "expected a dated otelite.log.* file with flushed startup lines; data dir contents: {:?}",
+            dated_log(&data_dir).is_some(),
+            "expected a dated otelite.log.* file (the M17 regression); data dir contents: {:?}, serve stderr:\n{}",
             std::fs::read_dir(&data_dir)
                 .map(|d| d.map(|e| e.unwrap().file_name()).collect::<Vec<_>>())
-                .unwrap_or_default()
+                .unwrap_or_default(),
+            stderr_tail(&data_dir)
         );
         std::thread::sleep(Duration::from_millis(200));
     }
@@ -518,4 +548,13 @@ fn test_serve_writes_rotating_log_file() {
             },
         }
     }
+
+    let final_len = log_len(&data_dir);
+    assert!(
+        final_len > 0,
+        "no log lines reached the dated file ({} bytes while running, {} bytes after clean shutdown); serve stderr:\n{}",
+        live_len,
+        final_len,
+        stderr_tail(&data_dir)
+    );
 }

--- a/crates/otelite/tests/service_discovery_test.rs
+++ b/crates/otelite/tests/service_discovery_test.rs
@@ -475,6 +475,10 @@ fn test_serve_writes_rotating_log_file() {
         .env("OTELITE_DATA_DIR", data_dir.as_os_str())
         .env("OTELITE_OTLP_GRPC_PORT", grpc_port.to_string())
         .env("OTELITE_OTLP_HTTP_PORT", http_port.to_string())
+        // Pin the child's logging filter: serve respects RUST_LOG, and an
+        // inherited value (e.g. from a build environment) would change what
+        // reaches the log file. Tests own their environment.
+        .env_remove("RUST_LOG")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::from(stderr_file))
         .spawn()
@@ -570,6 +574,28 @@ fn test_serve_writes_rotating_log_file() {
         }
         if s.is_empty() {
             s.push_str("(no /proc access — not Linux?)\n");
+        }
+        // The child's environment (log/otelite-relevant vars): an inherited
+        // RUST_LOG or similar would explain a healthy-looking process whose
+        // log file stays empty.
+        if let Ok(environ) = std::fs::read(format!("/proc/{pid}/environ")) {
+            let vars: Vec<&str> = environ
+                .split(|b| *b == 0)
+                .filter(|s| !s.is_empty())
+                .map(|s| std::str::from_utf8(s).unwrap_or(""))
+                .collect();
+            s.push_str("--- env (log/otelite-related) ---\n");
+            for v in &vars {
+                if v.starts_with("RUST_LOG")
+                    || v.starts_with("OTELITE_")
+                    || v.starts_with("TRACING")
+                    || v.starts_with("NO_COLOR")
+                    || v.starts_with("TERM")
+                {
+                    s.push_str(&format!("{v}\n"));
+                }
+            }
+            s.push_str(&format!("(total {} env vars)\n", vars.len()));
         }
         s
     };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -90,12 +90,14 @@ rustPlatform.buildRustPackage {
       [
         "--workspace"
         "--all-features"
+        "--no-fail-fast"
       ]
     else
       [
         "-p"
         "otelite"
         "--all-features"
+        "--no-fail-fast"
       ];
   doCheck = true;
   checkType = "debug";

--- a/scripts/rotate-changelog.sh
+++ b/scripts/rotate-changelog.sh
@@ -1,25 +1,167 @@
 #!/usr/bin/env bash
-# Rotate CHANGELOG.md [Unreleased] section into [X.Y.Z] - YYYY-MM-DD.
+# Rotate CHANGELOG.md [Unreleased] + changelog/*.md entries into [X.Y.Z] - DATE.
 #
 # Usage:
 #   scripts/rotate-changelog.sh <new_version> [date]
+#   scripts/rotate-changelog.sh --selftest
+#
+# Release notes come from two sources (either is fine, at least one is
+# required):
+#
+#   1. Bullets already under '## [Unreleased]' in CHANGELOG.md.
+#   2. Per-PR entry files in changelog/ (e.g. changelog/145.md). Each file
+#      holds that PR's notes: bullet lines, optionally grouped under
+#      '### Added' / '### Changed' / '### Fixed' / '### Removed' /
+#      '### Internal' headings. A file with no heading defaults to Added.
+#      Entry files are consumed (deleted) by the release commit.
 #
 # Behaviour:
-#   1. Verifies CHANGELOG.md has a [Unreleased] section with at least one
-#      bullet (a line starting with '- '). Fails with exit 1 if empty —
-#      this is the gate that stops a release from shipping with no notes.
-#   2. Renames `## [Unreleased]` → `## [<new_version>] - <date>`.
-#   3. Inserts a fresh empty `## [Unreleased]` block above it.
+#   1. Fails (exit 1) if neither source contains at least one bullet.
+#   2. Merges both sources, grouping by section in canonical order
+#      (Added, Changed, Fixed, Removed, Internal).
+#   3. Replaces '## [Unreleased]' with a fresh empty section followed by
+#      '## [<new_version>] - <date>' holding the merged sections.
+#   4. Deletes the consumed changelog/*.md entry files.
 #
 # Date defaults to UTC YYYY-MM-DD if not provided.
-#
-# The check is intentionally simple: presence of any bullet under
-# [Unreleased] before the next ## header. If you want to override (rare:
-# pure plumbing release), add a one-line "### Internal" note explaining
-# why — that satisfies the bullet requirement.
 
 set -euo pipefail
 
+CHANGELOG="${CHANGELOG_PATH:-CHANGELOG.md}"
+ENTRY_DIR="${ENTRY_DIR:-changelog}"
+
+# ---------------------------------------------------------------------------
+# Self-test: exercise the rotation in a temp dir, assert on the results.
+# ---------------------------------------------------------------------------
+if [[ "${1:-}" == "--selftest" ]]; then
+    script=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "$0")
+    tmp=$(mktemp -d)
+    trap 'rm -rf "$tmp"' EXIT
+    cd "$tmp"
+
+    base_changelog() {
+        cat > CHANGELOG.md <<'MD'
+# Changelog
+
+## [Unreleased]
+
+## [0.0.1] - 2026-01-01
+
+### Added
+
+- First release.
+MD
+    }
+
+    section() { # $1 = release version, $2 = release date, $3 = section name
+        # Prints the bullet lines of '### <section>' inside '## [<v>] - <date>'.
+        awk -v rel="## [$1] - $2" -v sec="### $3" '
+            $0 == rel { in_rel = 1; next }
+            in_rel && /^## / { in_rel = 0 }
+            in_rel && $0 == sec { in_sec = 1; next }
+            in_rel && in_sec && /^(##|###) / { in_sec = 0 }
+            in_rel && in_sec { print }
+        ' CHANGELOG.md
+    }
+
+    fail=0
+    check() { # $1 = description, $2 = actual, $3 = expected
+        if [[ "$2" == "$3" ]]; then
+            echo "  ok: $1"
+        else
+            echo "  FAIL: $1"
+            echo "    expected: $(printf '%q' "$3")"
+            echo "    actual:   $(printf '%q' "$2")"
+            fail=1
+        fi
+    }
+
+    echo "case 1: entry files only (default Added, section merge, consumption)"
+    base_changelog
+    mkdir changelog
+    echo "- Fix a bug in parsing." > changelog/2.md
+    printf '### Fixed\n\n- Crash on empty input.\n\n### Internal\n\n- Bump a dependency.\n' > changelog/10.md
+    "$script" 0.0.2 2026-01-02
+    check "releases section exists" "$(grep -c '^## \[0.0.2\] - 2026-01-02' CHANGELOG.md)" "1"
+    check "unreleased section exists" "$(grep -c '^## \[Unreleased\]' CHANGELOG.md)" "1"
+    check "unreleased is empty" "$(awk '/^## \[Unreleased\]/{f=1;next} f&&/^## /{f=0} f' CHANGELOG.md | grep -c '^- ' || true)" "0"
+    check "Added (no-heading file defaults to it)" "$(section 0.0.2 2026-01-02 Added | grep -c '^- ')" "1"
+    check "Fixed kept" "$(section 0.0.2 2026-01-02 Fixed | grep -c '^- ')" "1"
+    check "Internal kept" "$(section 0.0.2 2026-01-02 Internal | grep -c '^- ')" "1"
+    check "entry files consumed" "$(ls changelog/*.md 2>/dev/null | wc -l | tr -d ' ')" "0"
+
+    echo "case 2: [Unreleased] bullets only (backwards compatible)"
+    mkdir -p changelog
+    {
+        echo "# Changelog"
+        echo ""
+        echo "## [Unreleased]"
+        echo ""
+        echo "### Changed"
+        echo ""
+        echo "- New default port."
+        echo ""
+        echo "## [0.0.1] - 2026-01-01"
+        echo ""
+        echo "### Added"
+        echo ""
+        echo "- First release."
+    } > CHANGELOG.md
+    "$script" 0.0.3 2026-01-03
+    check "releases section exists" "$(grep -c '^## \[0.0.3\] - 2026-01-03' CHANGELOG.md)" "1"
+    check "Changed kept" "$(section 0.0.3 2026-01-03 Changed | grep -c '^- ')" "1"
+
+    echo "case 3: both sources merge (same section from both)"
+    {
+        echo "# Changelog"
+        echo ""
+        echo "## [Unreleased]"
+        echo ""
+        echo "### Fixed"
+        echo ""
+        echo "- Unreleased-side fix."
+        echo ""
+        echo "## [0.0.1] - 2026-01-01"
+        echo ""
+        echo "### Added"
+        echo ""
+        echo "- First release."
+    } > CHANGELOG.md
+    mkdir -p changelog
+    printf '### Fixed\n\n- Entry-side fix.\n' > changelog/7.md
+    "$script" 0.0.4 2026-01-04
+    check "Fixed merged from both sources" "$(section 0.0.4 2026-01-04 Fixed | grep -c '^- ')" "2"
+
+    echo "case 4: empty sources fail"
+    base_changelog
+    mkdir -p changelog
+    if "$script" 0.0.5 2026-01-05 2>/dev/null; then
+        check "empty release must fail" "succeeded" "failed"
+    else
+        check "empty release must fail" "failed" "failed"
+    fi
+
+    echo "case 5: unknown section heading fails"
+    base_changelog
+    mkdir -p changelog
+    printf '### Bogus\n\n- No.\n' > changelog/9.md
+    if "$script" 0.0.6 2026-01-06 2>/dev/null; then
+        check "unknown heading must fail" "succeeded" "failed"
+    else
+        check "unknown heading must fail" "failed" "failed"
+    fi
+
+    if [[ "$fail" -ne 0 ]]; then
+        echo "selftest: FAILED" >&2
+        exit 1
+    fi
+    echo "selftest: all cases passed"
+    exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Real rotation.
+# ---------------------------------------------------------------------------
 if [[ $# -lt 1 ]]; then
     echo "usage: $0 <new_version> [date]" >&2
     exit 2
@@ -27,7 +169,6 @@ fi
 
 NEW_VERSION="$1"
 RELEASE_DATE="${2:-$(date -u +%Y-%m-%d)}"
-CHANGELOG="${CHANGELOG_PATH:-CHANGELOG.md}"
 
 if [[ ! -f "$CHANGELOG" ]]; then
     echo "error: $CHANGELOG not found" >&2
@@ -41,38 +182,119 @@ unreleased_body=$(awk '
     in_section { print }
 ' "$CHANGELOG")
 
-# Require at least one bullet line.
-if ! grep -qE '^- ' <<<"$unreleased_body"; then
+# Collect entry files (dotfiles like .gitkeep/.template.md are ignored).
+entry_files=()
+if [[ -d "$ENTRY_DIR" ]]; then
+    while IFS= read -r f; do
+        entry_files+=("$f")
+    done < <(find "$ENTRY_DIR" -maxdepth 1 -name '*.md' ! -name '.*' | sort)
+fi
+
+unreleased_has_bullets=1
+grep -qE '^- ' <<<"$unreleased_body" || unreleased_has_bullets=0
+entry_bullet_count=0
+for f in "${entry_files[@]:-}"; do
+    [[ -n "$f" && -f "$f" ]] || continue
+    if grep -qE '^- ' "$f"; then
+        entry_bullet_count=$((entry_bullet_count + 1))
+    fi
+done
+
+if [[ "$unreleased_has_bullets" -eq 0 && "$entry_bullet_count" -eq 0 ]]; then
     cat >&2 <<EOF
-error: CHANGELOG.md [Unreleased] section is empty.
+error: no release notes found.
 
-Releases must ship with user-facing notes. Add at least one bullet
-under '## [Unreleased]' describing what users can now do (or what
-bug they no longer hit). See AGENTS.md → Changelog discipline.
+Releases must ship with user-facing notes. Add at least one bullet —
+either under '## [Unreleased]' in $CHANGELOG, or (preferred for PRs) in
+a new entry file '$ENTRY_DIR/<pr-number>.md' in this PR. See
+CONTRIBUTING.md → Changelog.
 
-If this is a pure plumbing release with no user impact, add:
+If this is a pure plumbing release with no user impact, use:
 
     ### Internal
     - <one-line reason>
-
-and re-run.
 EOF
     exit 1
 fi
 
-# Rotate: rename [Unreleased] → [X.Y.Z] - DATE, prepend fresh [Unreleased].
-# Use a temp file to avoid in-place sed portability issues (BSD vs GNU).
+# Build one stream of all note bodies. Entry files without any '### '
+# heading default to Added. Unknown headings fail loudly.
+stream=$(
+    printf '%s\n' "$unreleased_body"
+    for f in "${entry_files[@]:-}"; do
+        [[ -n "$f" && -f "$f" ]] || continue
+        if ! grep -qE '^### ' "$f"; then
+            printf '### Added\n\n'
+        fi
+        cat "$f"
+        printf '\n'
+    done
+)
+
+merged=$(
+    printf '%s\n' "$stream" | awk '
+        BEGIN {
+            n = split("Added Changed Fixed Removed Internal", order, " ")
+            for (i = 1; i <= n; i++) known[order[i]] = 1
+            cur = ""
+        }
+        /^### / {
+            name = $2
+            if (!(name in known)) {
+                printf "error: unknown section heading [%s] (expected one of: Added, Changed, Fixed, Removed, Internal)\n", name > "/dev/stderr"
+                bad = 1
+                exit 1
+            }
+            cur = name
+            next
+        }
+        {
+            if (cur == "") cur = "Added"   # bullets before any heading default to Added
+            body[cur] = body[cur] $0 "\n"
+        }
+        END {
+            if (bad) exit 1
+            for (i = 1; i <= n; i++) {
+                name = order[i]
+                b = body[name]
+                # Trim leading and trailing blank lines of the section body.
+                sub(/^[ \t\n]*\n?/, "", b)
+                sub(/\n[ \t\n]*$/, "", b)
+                if (b != "") {
+                    printf "### %s\n\n%s\n\n", name, b
+                }
+            }
+        }
+    '
+)
+
+# Rewrite the changelog: fresh empty [Unreleased] + release section with
+# the merged notes, replacing the old [Unreleased] section (heading and
+# body — the body's content is now in $merged).
 tmp=$(mktemp)
-awk -v ver="$NEW_VERSION" -v date="$RELEASE_DATE" '
+MERGED="$merged" awk '
     /^## \[Unreleased\]/ && !done {
         print "## [Unreleased]"
         print ""
         print "## [" ver "] - " date
+        print ""
+        # Command substitution stripped the trailing newlines of MERGED, so
+        # add the blank line before the next section header explicitly.
+        printf "%s\n\n", ENVIRON["MERGED"]
         done = 1
+        skip = 1
         next
     }
+    skip && /^## / { skip = 0 }
+    skip { next }
     { print }
-' "$CHANGELOG" > "$tmp"
+' ver="$NEW_VERSION" date="$RELEASE_DATE" "$CHANGELOG" > "$tmp"
 mv "$tmp" "$CHANGELOG"
 
-echo "rotated CHANGELOG.md: [Unreleased] → [$NEW_VERSION] - $RELEASE_DATE"
+# Consume the entry files.
+for f in "${entry_files[@]:-}"; do
+    [[ -n "$f" && -f "$f" ]] || continue
+    rm -f "$f"
+done
+
+echo "rotated CHANGELOG.md: [Unreleased] + ${#entry_files[@]} changelog entr(y/ies) → [$NEW_VERSION] - $RELEASE_DATE"


### PR DESCRIPTION
## Summary

Open PRs that edit `CHANGELOG.md` clash with every release that lands while they're open (each push to main rotates the changelog and cuts a release), and with each other when two PRs add bullets under the same `[Unreleased]` heading. Two contributor PRs have been in permanent conflict since 2026-08-27 for exactly this reason.

This makes each PR own its release notes in a new file, `changelog/<PR-number>.md`, that the release workflow merges into `CHANGELOG.md` and deletes. No shared-line edits, no clashes.

## Changes

- `scripts/rotate-changelog.sh`: merges `[Unreleased]` bullets **and** every `changelog/*.md` entry into the new release section in canonical order (Added, Changed, Fixed, Removed, Internal); deletes consumed entries; fails only when neither source has a bullet; unknown headings fail loudly; heading-less files default to Added. Backwards compatible with the old flow (plain `[Unreleased]` bullets still work).
- `scripts/rotate-changelog.sh --selftest`: five cases — entries-only, unreleased-only, both sources, empty gate, unknown heading.
- `changelog/.template.md` + `.gitkeep`: contributor template (dotfile, never consumed).
- `bump-and-tag.yml`: release commit stages `changelog/` so consumed entries are deleted.
- Docs: new 'Changelog Entry' section in CONTRIBUTING.md (+ checklist items); AGENTS.md changelog discipline updated.

## Testing

- `scripts/rotate-changelog.sh --selftest` — all 5 cases pass
- `cargo test --workspace` — 1454 passed, 0 failed
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

## Checklist

- [x] Tests added/updated (script selftest)
- [x] Documentation updated (CONTRIBUTING, AGENTS)
- [x] Breaking changes documented (none — additive; old flow still works)
- [x] Changelog entry added: changelog/<this-PR>.md (added after PR creation)

Follow-up (separate, after merge): migrate the two open contributor PRs to entry files and rebase them.