### PR TITLE
Group analytics reports into categories + report filter + pins

### DIFF
--- a/changelog/187.md
+++ b/changelog/187.md
@@ -1,0 +1,5 @@
+### Added
+
+- GenAI Analytics reports are grouped into five collapsible categories (Cost, Latency, Reliability, Behaviour, Ecosystem & Diagnostics) — the page opens as five rows instead of a 28-section scroll
+- Filter GenAI Analytics reports by name, description, or category name; matching categories open automatically and clearing restores your previous layout
+- Pin GenAI Analytics reports to the top with the 📌 button — pins survive reloads and pinned reports open expanded

--- a/crates/otelite-api/static/css/styles.css
+++ b/crates/otelite-api/static/css/styles.css
@@ -2423,6 +2423,115 @@ details[open] > .json-tree-summary::before {
     pointer-events: none;
 }
 
+/* --- Analytics report categories, filter box, and pins (#186) --- */
+
+.analytics-report-tools {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.analytics-report-tools .filter-input {
+    max-width: 320px;
+}
+
+.analytics-filter-count {
+    color: var(--text-secondary);
+    font-size: 0.85rem;
+    white-space: nowrap;
+}
+
+.analytics-group {
+    margin-bottom: 0.75rem;
+    border: 1px solid var(--border-color);
+    border-radius: 4px;
+    background-color: var(--bg-primary);
+}
+
+.analytics-group-pinned {
+    border-color: var(--accent-color);
+}
+
+.analytics-group-summary {
+    display: flex;
+    align-items: baseline;
+    gap: 0.75rem;
+    padding: 0.65rem 1rem;
+    background-color: var(--bg-tertiary);
+    cursor: pointer;
+    user-select: none;
+    list-style: none;
+    transition: background-color 0.15s;
+}
+
+.analytics-group-summary::-webkit-details-marker { display: none; }
+.analytics-group-summary::marker { content: ''; }
+
+.analytics-group-summary::before {
+    content: '▸';
+    display: inline-block;
+    font-size: 0.9em;
+    color: var(--text-secondary);
+    transition: transform 0.15s;
+    width: 0.9em;
+}
+
+.analytics-group[open] > .analytics-group-summary::before {
+    transform: rotate(90deg);
+}
+
+.analytics-group-summary:hover {
+    background-color: rgba(129, 140, 248, 0.1);
+}
+
+.analytics-group-title {
+    font-weight: 700;
+    font-size: 1.05rem;
+    color: var(--text-primary);
+}
+
+.analytics-group-count {
+    color: var(--text-secondary);
+    font-size: 0.8rem;
+}
+
+.analytics-group-body {
+    padding: 0.75rem 1rem;
+    background-color: var(--bg-secondary);
+    border-top: 1px solid var(--border-color);
+}
+
+/* Nested report sections inside a category */
+.analytics-group-body .analytics-section {
+    margin-bottom: 0.5rem;
+}
+
+.analytics-group-body .analytics-section:last-child {
+    margin-bottom: 0;
+}
+
+.pin-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    margin-right: 0.1rem;
+    font-size: 0.85em;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.3;
+    transition: opacity 0.15s, transform 0.15s;
+}
+
+.pin-btn:hover {
+    opacity: 1;
+    transform: scale(1.15);
+}
+
+.pin-btn.pinned {
+    opacity: 1;
+}
+
 .usage-summary-cards {
     display: flex;
     gap: 1rem;

--- a/crates/otelite-api/static/js/analytics.js
+++ b/crates/otelite-api/static/js/analytics.js
@@ -1,8 +1,11 @@
 // GenAI analytics view
 //
-// Replaces the old "Usage" tab. The page is organised as 4 collapsed
-// <details> accordion sections grouped by question:
-//   Cost · Latency · Reliability · Behavior
+// The page is organised as 5 collapsed <details> category groups
+// (Cost · Latency · Reliability · Behaviour · Ecosystem & Diagnostics),
+// each holding its report sections as nested accordions — the flat
+// 28-section stack predates the grouping (#186). A filter box narrows the
+// reports by title, hint, or category name, and 📌 pins reports to a
+// top-level Pinned group (persisted in localStorage).
 // On initial load only a single cheap getTokenUsage summary call (plus the
 // static pricing metadata) is made — every chart inside a section is fetched
 // lazily on first expand and cached thereafter.
@@ -31,6 +34,49 @@ function chartAxisLabel(tsNs, multiDay) {
 }
 
 class AnalyticsView {
+    // Report registry — every analytics report with its title and hint.
+    // Categories (GROUPS) organise these into the page's top-level groups.
+    static REPORTS = [
+        { id: 'cost',                    title: 'Cost',                    hint: 'Tokens spent · pricing · most expensive calls' },
+        { id: 'providers',               title: 'Provider Mix',            hint: 'Tokens & estimated cost by provider × model (opencode · codex · claude)' },
+        { id: 'roles',                   title: 'Agent Roles',             hint: 'Sub-agent attribution · cost & tokens per role · role × model routing matrix (opencode)' },
+        { id: 'session_model',           title: 'Session × Model',         hint: 'Token and cost breakdown per (session, model) pair — spot opus spend in specific sessions' },
+        { id: 'effort',                  title: 'Effort Breakdown',        hint: 'Claude Code token usage by effort level (low/medium/high/xhigh) × model × type' },
+        { id: 'efficiency',              title: 'Agent Efficiency',        hint: 'Tokens per commit · tokens per line of code · cross-agent comparison' },
+        { id: 'skill_outcomes',          title: 'Skill Outcomes',          hint: 'Token efficiency comparison: sessions that used each skill vs sessions that did not' },
+        { id: 'latency',                 title: 'Latency',                 hint: 'Response time · throughput · context size' },
+        { id: 'model_performance',       title: 'Model Performance',       hint: 'Per-model duration · throughput · TTFT · error diagnosis vs preceding & rolling baselines' },
+        { id: 'codex_ttft',              title: 'Codex TTFT',              hint: 'First-token latency percentiles (p50/p90/p95) per model from histogram metrics' },
+        { id: 'cross_tool_ttft',         title: 'Cross-Tool TTFT',         hint: 'First-token latency by model across all tools (Claude Code, opencode, pi) from span attributes' },
+        { id: 'codex_turns',             title: 'Codex Busy/Idle',         hint: 'Average busy vs idle time per turn by model and project' },
+        { id: 'speed_dist',              title: 'Speed / Effort Mode',     hint: 'Distribution of the Claude Code speed attribute (normal / extended thinking) by model' },
+        { id: 'reliability',             title: 'Reliability',             hint: 'Errors · retries · truncation · drift' },
+        { id: 'recent_errors',           title: 'Recent Errors',           hint: 'Latest error events from spans and logs — OTel ERROR status, bad finish reasons, and log ERROR records' },
+        { id: 'session_quality',         title: 'Session Quality',         hint: 'Clean / degraded / errored breakdown — spot sessions that truncated, retried, or failed' },
+        { id: 'mcp_health',              title: 'MCP Health',              hint: 'Call success/error rates per MCP server and tool — spot flaky integrations' },
+        { id: 'tool_failure_rates',      title: 'Tool Failure Rates',      hint: 'Failure % per opencode tool — spot flaky or broken integrations at a glance' },
+        { id: 'guardian',                title: 'Guardian Reviews',        hint: 'Risk levels · denial rate by action type · what the guardian is actually blocking' },
+        { id: 'behavior',                title: 'Behavior',                hint: 'Tool use · retrieval · request volume' },
+        { id: 'multi_agent',             title: 'Multi-Agent Topology',    hint: 'Sub-agent spawn and resume counts by role' },
+        { id: 'daily_tool_mix',          title: 'Daily Tool Mix',          hint: 'Claude Code / opencode / Codex activity per calendar day — when you use each tool' },
+        { id: 'model_selection_heatmap', title: 'Model Selection Heatmap', hint: 'Which tool picked which model for which agent role — (role × tool × model) request counts' },
+        { id: 'reasoning_share',         title: 'Reasoning Token Share',   hint: 'Thinking tokens as a percentage of output tokens per model — opencode + Codex' },
+        { id: 'skill_activity',          title: 'Skills Activity',         hint: 'Which Codex skills fire most — implicit injection counts by skill name' },
+        { id: 'hook_overhead',           title: 'Hook Overhead',           hint: 'Codex hook total and average invocation time per event type — how much latency hooks add' },
+        { id: 'capabilities',            title: 'Telemetry Capabilities',  hint: 'Which metrics each emitter actually provides · availability & quality' },
+        { id: 'project_rollup',          title: 'Project Rollup',          hint: 'Token activity and turn counts per project across all agents' },
+    ];
+
+    // Top-level categories. A report appears in exactly one group; pinned
+    // reports move to the Pinned group while pinned.
+    static GROUPS = [
+        { id: 'cost',        label: 'Cost',                    reports: ['cost', 'providers', 'roles', 'session_model', 'effort', 'efficiency', 'skill_outcomes'] },
+        { id: 'latency',     label: 'Latency',                 reports: ['latency', 'model_performance', 'codex_ttft', 'cross_tool_ttft', 'codex_turns', 'speed_dist'] },
+        { id: 'reliability', label: 'Reliability',             reports: ['reliability', 'recent_errors', 'session_quality', 'mcp_health', 'tool_failure_rates', 'guardian'] },
+        { id: 'behavior',    label: 'Behaviour',               reports: ['behavior', 'multi_agent', 'daily_tool_mix', 'model_selection_heatmap', 'reasoning_share'] },
+        { id: 'ecosystem',   label: 'Ecosystem & Diagnostics', reports: ['skill_activity', 'hook_overhead', 'capabilities', 'project_rollup'] },
+    ];
+
     constructor(apiClient) {
         this.api = apiClient;
         this.refreshInterval = null;
@@ -63,6 +109,15 @@ class AnalyticsView {
         // Track open state across re-renders
         this.openSections = new Set();
         this.lastSummary = null;
+        // Pinned reports (#186) — persisted in localStorage; rendered in a
+        // top-level Pinned group and open by default.
+        this.pinned = this._loadPins();
+        // Active report-filter query ('' = unfiltered) + the group open-state
+        // snapshot taken at the start of a filter session, so clearing the
+        // filter restores the previous layout.
+        this._filterQuery = '';
+        this._groupOpenSnapshot = null;
+        this._sectionsEl = null;
     }
 
     async render() {
@@ -97,34 +152,18 @@ class AnalyticsView {
             <div id="analytics-summary-cards"></div>
             <div id="analytics-empty-state"></div>
             <div id="analytics-sections">
-                ${this._renderSectionShell('cost', 'Cost', 'Tokens spent · pricing · most expensive calls')}
-                ${this._renderSectionShell('tool_failure_rates', 'Tool Failure Rates', 'Failure % per opencode tool — spot flaky or broken integrations at a glance')}
-                ${this._renderSectionShell('daily_tool_mix', 'Daily Tool Mix', 'Claude Code / opencode / Codex activity per calendar day — when you use each tool')}
-                ${this._renderSectionShell('roles', 'Agent Roles', 'Sub-agent attribution · cost & tokens per role · role × model routing matrix (opencode)')}
-                ${this._renderSectionShell('providers', 'Provider Mix', 'Tokens & estimated cost by provider × model (opencode · codex · claude)')}
-                ${this._renderSectionShell('latency', 'Latency', 'Response time · throughput · context size')}
-                ${this._renderSectionShell('reliability', 'Reliability', 'Errors · retries · truncation · drift')}
-                ${this._renderSectionShell('behavior', 'Behavior', 'Tool use · retrieval · request volume')}
-                ${this._renderSectionShell('skill_activity', 'Skills Activity', 'Which Codex skills fire most — implicit injection counts by skill name')}
-                ${this._renderSectionShell('capabilities', 'Telemetry Capabilities', 'Which metrics each emitter actually provides · availability & quality')}
-                ${this._renderSectionShell('model_performance', 'Model Performance', 'Per-model duration · throughput · TTFT · error diagnosis vs preceding & rolling baselines')}
-                ${this._renderSectionShell('effort', 'Effort Breakdown', 'Claude Code token usage by effort level (low/medium/high/xhigh) × model × type')}
-                ${this._renderSectionShell('efficiency', 'Agent Efficiency', 'Tokens per commit · tokens per line of code · cross-agent comparison')}
-                ${this._renderSectionShell('codex_ttft', 'Codex TTFT', 'First-token latency percentiles (p50/p90/p95) per model from histogram metrics')}
-                ${this._renderSectionShell('project_rollup', 'Project Rollup', 'Token activity and turn counts per project across all agents')}
-                ${this._renderSectionShell('mcp_health', 'MCP Health', 'Call success/error rates per MCP server and tool — spot flaky integrations')}
-                ${this._renderSectionShell('guardian', 'Guardian Reviews', 'Risk levels · denial rate by action type · what the guardian is actually blocking')}
-                ${this._renderSectionShell('multi_agent', 'Multi-Agent Topology', 'Sub-agent spawn and resume counts by role')}
-                ${this._renderSectionShell('codex_turns', 'Codex Busy/Idle', 'Average busy vs idle time per turn by model and project')}
-                ${this._renderSectionShell('session_model', 'Session × Model', 'Token and cost breakdown per (session, model) pair — spot opus spend in specific sessions')}
-                ${this._renderSectionShell('speed_dist', 'Speed / Effort Mode', 'Distribution of the Claude Code speed attribute (normal / extended thinking) by model')}
-                ${this._renderSectionShell('cross_tool_ttft', 'Cross-Tool TTFT', 'First-token latency by model across all tools (Claude Code, opencode, pi) from span attributes')}
-                ${this._renderSectionShell('session_quality', 'Session Quality', 'Clean / degraded / errored breakdown — spot sessions that truncated, retried, or failed')}
-                ${this._renderSectionShell('hook_overhead', 'Hook Overhead', 'Codex hook total and average invocation time per event type — how much latency hooks add')}
-                ${this._renderSectionShell('reasoning_share', 'Reasoning Token Share', 'Thinking tokens as a percentage of output tokens per model — opencode + Codex')}
-                ${this._renderSectionShell('skill_outcomes', 'Skill Outcomes', 'Token efficiency comparison: sessions that used each skill vs sessions that did not')}
-                ${this._renderSectionShell('model_selection_heatmap', 'Model Selection Heatmap', 'Which tool picked which model for which agent role — (role × tool × model) request counts')}
-                ${this._renderSectionShell('recent_errors', 'Recent Errors', 'Latest error events from spans and logs — OTel ERROR status, bad finish reasons, and log ERROR records')}
+                <div class="analytics-report-tools">
+                    <input type="search" id="analytics-report-filter" class="filter-input"
+                           placeholder="Filter reports… (e.g. ttft, cost, mcp)" autocomplete="off">
+                    <span id="analytics-filter-count" class="analytics-filter-count"></span>
+                </div>
+                ${[
+                    (this.pinned.size ? this._renderGroupShell('pinned', 'Pinned', [...this.pinned], true) : ''),
+                    ...AnalyticsView.GROUPS.map(g => {
+                        const ids = g.reports.filter(id => !this.pinned.has(id));
+                        return ids.length ? this._renderGroupShell(g.id, g.label, ids) : '';
+                    }),
+                ].join('')}
             </div>
         `;
 
@@ -137,6 +176,16 @@ class AnalyticsView {
 
         this._registerSectionLoaders();
         this._attachSectionToggleHandlers();
+        this._attachReportTools();
+        // Pinned sections mount already open; the toggle event that would
+        // lazy-load them doesn't fire on initial creation, so fire their
+        // loaders explicitly.
+        for (const id of this.pinned) {
+            this.openSections.add(id);
+            if (!this.loadedSections.has(id)) {
+                this.sectionLoaders[id]();
+            }
+        }
 
         await this._loadSummary();
 
@@ -145,19 +194,198 @@ class AnalyticsView {
         }
     }
 
-    _renderSectionShell(id, title, hint) {
-        const open = this.openSections.has(id);
+    _renderGroupShell(gid, label, reportIds, open = false) {
+        // reportIds may be empty (a freshly created Pinned group) — the
+        // caller then appends the moved <details> element itself.
+        const sections = (reportIds || []).map(id => this._renderSectionShell(id)).join('');
+        const n = (reportIds || []).length;
+        return `
+            <details class="analytics-group${gid === 'pinned' ? ' analytics-group-pinned' : ''}" id="analytics-group-${gid}"${open ? ' open' : ''}>
+                <summary class="analytics-group-summary">
+                    <span class="analytics-group-title">${label}</span>
+                    <span class="analytics-group-count" id="analytics-group-count-${gid}">${n} report${n === 1 ? '' : 's'}</span>
+                </summary>
+                <div class="analytics-group-body" id="analytics-group-body-${gid}">${sections}</div>
+            </details>`;
+    }
+
+    _renderSectionShell(id) {
+        const r = AnalyticsView.REPORTS.find(x => x.id === id);
+        if (!r) return '';
+        const pinned = this.pinned.has(id);
+        const open = pinned || this.openSections.has(id);
         return `
             <details class="analytics-section" id="analytics-section-${id}"${open ? ' open' : ''}>
                 <summary class="analytics-section-summary">
-                    <span class="analytics-section-title">${title}</span>
-                    <span class="analytics-section-hint">${hint}</span>
+                    <button type="button" class="pin-btn${pinned ? ' pinned' : ''}" data-pin="${id}"
+                            aria-pressed="${pinned}" title="${pinned ? 'Unpin report' : 'Pin report to top'}">&#128204;</button>
+                    <span class="analytics-section-title">${r.title}</span>
+                    <span class="analytics-section-hint">${r.hint}</span>
                     <span class="analytics-section-stat" id="analytics-section-stat-${id}">—</span>
                 </summary>
                 <div class="analytics-section-body" id="analytics-section-body-${id}">
                     <div class="empty-state-hint">Loading…</div>
                 </div>
             </details>`;
+    }
+
+    _loadPins() {
+        try {
+            const raw = JSON.parse(localStorage.getItem('otelite.analytics.pinned') || '[]');
+            const valid = new Set(AnalyticsView.REPORTS.map(r => r.id));
+            return new Set(Array.isArray(raw) ? raw.filter(id => valid.has(id)) : []);
+        } catch {
+            // Corrupt storage — start unpinned rather than failing the view.
+            return new Set();
+        }
+    }
+
+    _savePins() {
+        try {
+            localStorage.setItem('otelite.analytics.pinned', JSON.stringify([...this.pinned]));
+        } catch {
+            // Storage unavailable (e.g. private browsing) — pins stay
+            // session-only; nothing else depends on them.
+        }
+    }
+
+    _attachReportTools() {
+        this._sectionsEl = document.getElementById('analytics-sections');
+        const filterInput = document.getElementById('analytics-report-filter');
+        if (filterInput) {
+            filterInput.addEventListener('input', () => this._applyReportFilter(filterInput.value));
+        }
+        // Pin buttons live inside <summary>; intercept the click before it
+        // toggles the details element.
+        this._sectionsEl.addEventListener('click', (e) => {
+            const btn = e.target.closest('.pin-btn');
+            if (!btn) return;
+            e.preventDefault();
+            e.stopPropagation();
+            this._togglePin(btn.dataset.pin);
+        });
+        this._applyReportFilter(this._filterQuery);
+    }
+
+    _applyReportFilter(query) {
+        const q = (query || '').trim().toLowerCase();
+        this._filterQuery = q;
+        const groups = [...document.querySelectorAll('.analytics-group')];
+        // Snapshot group open-state at the start of a filter session so
+        // clearing the filter restores the previous layout.
+        let restore = null;
+        if (q && !this._groupOpenSnapshot) {
+            this._groupOpenSnapshot = groups.filter(g => g.open).map(g => g.id);
+        }
+        if (!q) {
+            restore = this._groupOpenSnapshot;
+            this._groupOpenSnapshot = null;
+        }
+
+        const total = Object.keys(this.sectionLoaders).length;
+        let visible = 0;
+        for (const id of Object.keys(this.sectionLoaders)) {
+            const el = document.getElementById(`analytics-section-${id}`);
+            if (!el) continue;
+            const title = (el.querySelector('.analytics-section-title')?.textContent || '').toLowerCase();
+            const hint = (el.querySelector('.analytics-section-hint')?.textContent || '').toLowerCase();
+            // A query matching a category name shows every report in it.
+            const hostGroup = el.closest('.analytics-group');
+            const groupMatch = hostGroup &&
+                (hostGroup.querySelector('.analytics-group-title')?.textContent || '').toLowerCase().includes(q);
+            const match = !q || title.includes(q) || hint.includes(q) || groupMatch;
+            el.hidden = !match;
+            if (match) visible++;
+        }
+        for (const g of groups) {
+            const hasVisible = [...g.querySelectorAll('.analytics-section')].some(s => !s.hidden);
+            g.hidden = !hasVisible;
+            if (q) {
+                // While filtering, matching categories open automatically.
+                g.open = hasVisible;
+            } else if (restore) {
+                // Filter cleared — restore the pre-filter layout.
+                g.open = restore.includes(g.id);
+            }
+            // No filter and no snapshot: leave open state untouched (initial
+            // render — e.g. the Pinned group mounts open).
+        }
+        const count = document.getElementById('analytics-filter-count');
+        if (count) count.textContent = q ? `${visible} of ${total} reports` : `${total} reports`;
+    }
+
+    _recountGroups() {
+        for (const g of document.querySelectorAll('.analytics-group')) {
+            const body = g.querySelector('.analytics-group-body');
+            const countEl = g.querySelector('.analytics-group-count');
+            if (!body || !countEl) continue;
+            const n = body.querySelectorAll('.analytics-section').length;
+            countEl.textContent = n ? `${n} report${n === 1 ? '' : 's'}` : 'no reports';
+        }
+    }
+
+    _ensureCategoryGroupBody(group) {
+        let body = document.getElementById(`analytics-group-body-${group.id}`);
+        if (body) return body;
+        // The category was empty when the page rendered (all of its reports
+        // were pinned) — recreate its shell, keeping category order.
+        const wrap = document.createElement('div');
+        wrap.innerHTML = this._renderGroupShell(group.id, group.label, []);
+        const newGroup = wrap.firstElementChild;
+        const myOrder = AnalyticsView.GROUPS.findIndex(g => g.id === group.id);
+        let anchor = null;
+        for (const g of AnalyticsView.GROUPS) {
+            if (AnalyticsView.GROUPS.findIndex(x => x.id === g.id) <= myOrder) continue;
+            const el = document.getElementById(`analytics-group-${g.id}`);
+            if (el) {
+                anchor = el;
+                break;
+            }
+        }
+        if (anchor) this._sectionsEl.insertBefore(newGroup, anchor);
+        else this._sectionsEl.appendChild(newGroup);
+        return newGroup.querySelector('.analytics-group-body');
+    }
+
+    _togglePin(id) {
+        const sectionEl = document.getElementById(`analytics-section-${id}`);
+        if (!sectionEl) return;
+        if (this.pinned.has(id)) {
+            this.pinned.delete(id);
+            // Move the report back into its category.
+            const group = AnalyticsView.GROUPS.find(g => g.reports.includes(id));
+            if (group) this._ensureCategoryGroupBody(group).appendChild(sectionEl);
+            // Drop the Pinned group once it is empty.
+            const pinnedGroup = document.getElementById('analytics-group-pinned');
+            if (pinnedGroup && !pinnedGroup.querySelector('.analytics-section')) {
+                pinnedGroup.remove();
+            }
+        } else {
+            this.pinned.add(id);
+            let pinnedGroup = document.getElementById('analytics-group-pinned');
+            if (!pinnedGroup) {
+                const wrap = document.createElement('div');
+                wrap.innerHTML = this._renderGroupShell('pinned', 'Pinned', [], true);
+                pinnedGroup = wrap.firstElementChild;
+                const tools = document.querySelector('.analytics-report-tools');
+                if (tools) this._sectionsEl.insertBefore(pinnedGroup, tools.nextSibling);
+                else this._sectionsEl.prepend(pinnedGroup);
+            }
+            pinnedGroup.querySelector('.analytics-group-body').appendChild(sectionEl);
+            // Pinned reports open by default; setting .open fires the
+            // toggle handler, which records the state and lazy-loads.
+            sectionEl.open = true;
+        }
+        this._savePins();
+        const btn = sectionEl.querySelector('.pin-btn');
+        if (btn) {
+            const on = this.pinned.has(id);
+            btn.classList.toggle('pinned', on);
+            btn.setAttribute('aria-pressed', String(on));
+            btn.title = on ? 'Unpin report' : 'Pin report to top';
+        }
+        this._recountGroups();
+        this._applyReportFilter(this._filterQuery);
     }
 
     _renderTipsPanel() {
@@ -170,8 +398,9 @@ class AnalyticsView {
                         <div class="tips-col">
                             <strong>Layout</strong>
                             <ul>
-                                <li>Sections lazy-load on first expand</li>
-                                <li>Top-spans table is under <strong>Cost</strong> — sort dropdown switches view</li>
+                                <li>Reports are grouped into categories; all lazy-load on first expand</li>
+                                <li>The filter box matches report titles, hints, and category names; matching categories open automatically</li>
+                                <li>&#128204; pins a report to the top (saved in your browser); Top-spans table is under <strong>Cost</strong> — sort dropdown switches view</li>
                             </ul>
                             <strong>Widgets</strong>
                             <ul>

--- a/crates/otelite-api/tests/js/analytics_groups.test.mjs
+++ b/crates/otelite-api/tests/js/analytics_groups.test.mjs
@@ -1,0 +1,138 @@
+// Parity tests for the analytics report categories, filter, and pins
+// (issue #186). Runs under `node --test` (no dependencies): asserts the
+// REPORTS/GROUPS registries stay in lockstep with the sectionLoaders
+// registry (so a new report cannot be added to one and forgotten in the
+// others), and the rendering of the group/section shells including the
+// pin button and open-by-default behaviour for pinned reports.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, '../../static/js/analytics.js'), 'utf8');
+const moduleObj = { exports: {} };
+new Function('module', 'exports', 'window', 'parseHashQuery', 'parseHashWindow', src)(
+    moduleObj,
+    moduleObj.exports,
+    undefined,
+    () => ({}),
+    () => null,
+);
+const { AnalyticsView } = moduleObj.exports;
+
+const view = Object.create(AnalyticsView.prototype);
+// Constructor state used by the shell renderers (the node fixture skips the
+// constructor to avoid side effects — mirror the fields it would set).
+view.sectionLoaders = {};
+view.openSections = new Set();
+view.pinned = new Set();
+
+// Minimal localStorage stub for the pin persistence tests.
+function stubLocalStorage(items = {}) {
+    const store = new Map(Object.entries(items));
+    return {
+        getItem: (k) => (store.has(k) ? store.get(k) : null),
+        setItem: (k, v) => store.set(k, String(v)),
+        _dump: () => Object.fromEntries(store),
+    };
+}
+
+test('REPORTS registry matches the sectionLoaders keys exactly', () => {
+    view._registerSectionLoaders();
+    const loaderKeys = new Set(Object.keys(view.sectionLoaders));
+    const reportIds = new Set(AnalyticsView.REPORTS.map(r => r.id));
+
+    assert.equal(reportIds.size, AnalyticsView.REPORTS.length, 'duplicate report ids');
+    assert.equal(loaderKeys.size, reportIds.size, 'REPORTS and sectionLoaders drifted');
+    for (const id of reportIds) {
+        assert.ok(loaderKeys.has(id), `report '${id}' has no section loader`);
+    }
+    for (const r of AnalyticsView.REPORTS) {
+        assert.ok(r.title.length > 0, `report '${r.id}' has an empty title`);
+        assert.ok(r.hint.length > 0, `report '${r.id}' has an empty hint`);
+    }
+});
+
+test('GROUPS partition the REPORTS — every report in exactly one group', () => {
+    const reportIds = new Set(AnalyticsView.REPORTS.map(r => r.id));
+    const seen = new Set();
+    for (const g of AnalyticsView.GROUPS) {
+        assert.ok(g.id.length > 0 && g.label.length > 0, 'group missing id/label');
+        for (const id of g.reports) {
+            assert.ok(reportIds.has(id), `group '${g.id}' lists unknown report '${id}'`);
+            assert.ok(!seen.has(id), `report '${id}' is in more than one group`);
+            seen.add(id);
+        }
+    }
+    assert.equal(seen.size, reportIds.size, 'some reports are not in any group');
+});
+
+test('_renderGroupShell renders nested section shells and the count label', () => {
+    view.pinned = new Set();
+    const html = view._renderGroupShell('latency', 'Latency', ['latency', 'codex_ttft']);
+    assert.match(html, /<details class="analytics-group" id="analytics-group-latency">/);
+    assert.match(html, /<span class="analytics-group-title">Latency<\/span>/);
+    assert.match(html, /<span class="analytics-group-count" id="analytics-group-count-latency">2 reports<\/span>/);
+    assert.match(html, /id="analytics-section-latency"/);
+    assert.match(html, /id="analytics-section-codex_ttft"/);
+});
+
+test('_renderGroupShell honours the open flag and pinned styling', () => {
+    view.pinned = new Set();
+    assert.match(view._renderGroupShell('cost', 'Cost', ['cost'], true), /<details[^>]+ id="analytics-group-cost" open>/);
+    assert.doesNotMatch(view._renderGroupShell('cost', 'Cost', ['cost']), /open/);
+    assert.match(
+        view._renderGroupShell('pinned', 'Pinned', ['cost']),
+        /class="analytics-group analytics-group-pinned" id="analytics-group-pinned"/,
+    );
+    // Empty report list (fresh Pinned group) still renders the shell —
+    // the caller appends the moved <details> element afterwards.
+    const empty = view._renderGroupShell('pinned', 'Pinned', []);
+    assert.match(empty, /id="analytics-group-body-pinned"><\/div>[\s]*<\/details>[\s]*$/);
+    assert.doesNotMatch(empty, /analytics-section-/);
+});
+
+test('_renderSectionShell renders the pin button and pinned open state', () => {
+    view.pinned = new Set();
+    const plain = view._renderSectionShell('cost');
+    assert.match(plain, /<details class="analytics-section" id="analytics-section-cost">/);
+    assert.match(plain, /class="pin-btn" data-pin="cost"[\s\S]*aria-pressed="false"/);
+    assert.doesNotMatch(plain, /open/);
+
+    view.pinned = new Set(['cost']);
+    const pinned = view._renderSectionShell('cost');
+    assert.match(pinned, /<details class="analytics-section" id="analytics-section-cost" open>/);
+    assert.match(pinned, /class="pin-btn pinned" data-pin="cost"[\s\S]*aria-pressed="true"/);
+    assert.match(pinned, /title="Unpin report"/);
+
+    assert.equal(view._renderSectionShell('no_such_report'), '');
+});
+
+test('_loadPins keeps valid ids and drops corrupt storage', () => {
+    globalThis.localStorage = stubLocalStorage({
+        'otelite.analytics.pinned': JSON.stringify(['cost', 'no_such_report', 'latency']),
+    });
+    const pins = view._loadPins();
+    assert.deepEqual([...pins].sort(), ['cost', 'latency']);
+
+    globalThis.localStorage = stubLocalStorage({ 'otelite.analytics.pinned': '{corrupt' });
+    assert.equal(view._loadPins().size, 0);
+
+    globalThis.localStorage = stubLocalStorage({ 'otelite.analytics.pinned': '{"a":1}' });
+    assert.equal(view._loadPins().size, 0);
+
+    delete globalThis.localStorage;
+    // No localStorage at all (node, private browsing) — unpinned, no throw.
+    assert.equal(view._loadPins().size, 0);
+});
+
+test('_savePins writes the pinned id list as JSON', () => {
+    const ls = stubLocalStorage();
+    globalThis.localStorage = ls;
+    view.pinned = new Set(['cost', 'latency']);
+    view._savePins();
+    assert.deepEqual(JSON.parse(ls._dump()['otelite.analytics.pinned']), ['cost', 'latency']);
+    delete globalThis.localStorage;
+});


### PR DESCRIPTION
## What changed

The GenAI Analytics page (`#/analytics`) had drifted from its original design
of 4 grouped sections into a flat stack of **28 sibling accordions** — a
28-row scroll even fully collapsed, with every report title competing for
attention and each new report making it longer.

This restores hierarchy and adds two ways to narrow the 28:

- **Category groups.** The 28 reports are organised into 5 collapsible
  categories (Cost · Latency · Reliability · Behaviour · Ecosystem &
  Diagnostics). The collapsed page is now 5 rows. The report registry
  (`AnalyticsView.REPORTS`) is the single source for titles/hints, and
  `GROUPS` declares the partition.
- **Report filter box.** Substring-matches report titles, hints, and
  category names (typing "reliability" opens the Reliability category).
  Non-matching reports and empty categories hide; matching categories
  auto-open while filtering; clearing the filter restores the previous
  open/closed layout (snapshot taken at the first keystroke). A
  "N of 28 reports" counter sits beside the box.
- **Pins.** Every report row has a 📌 button. Pinned reports move to an
  accent-bordered "Pinned" category at the top, expanded by default, and
  are remembered in `localStorage` (`otelite.analytics.pinned`) across
  reloads. Unpinning returns the report to its category — including
  recreating the category shell if all of its reports were pinned at
  page load.

No API surface changes; the per-section lazy-load architecture
(`sectionLoaders`, `openSections`, `loadedSections`, stat chips, 30 s
refresh) is preserved. Pins and filtering are DOM operations on the
once-rendered view, so already-loaded charts survive pin/unpin/filter.

## Verification

- `node --test crates/otelite-api/tests/js/*.test.mjs` — 20/20 pass,
  including 7 new tests: registry drift guard (REPORTS keys ==
  sectionLoaders keys), GROUPS partition check, group/section shell
  rendering, pin-button state, `_loadPins` corrupt-storage handling,
  `_savePins` round-trip.
- Headless-browser QA against a test daemon (ephemeral port, temp data
  dir seeded with synthetic OTLP GenAI spans): default 5-group/28-section
  layout, "ttft" filter → exactly 3 matches with auto-open, category-name
  filter, clear-restores-layout, pin/unpin with live count relabels,
  pin persistence across reload, all-category-pinned edge case, lazy-load
  through nesting, zero console/network errors.
- Quality gates: cargo build/test/clippy/fmt on the workspace.

Closes #186.