### PR TITLE
Fix cross-tool report loaders calling nonexistent _timeParams

### DIFF
--- a/changelog/193.md
+++ b/changelog/193.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Three GenAI Analytics reports (Cross-Tool TTFT, Hook Overhead, Reasoning Token Share) that failed to load on every expand now work

--- a/crates/otelite-api/static/js/analytics.js
+++ b/crates/otelite-api/static/js/analytics.js
@@ -3673,7 +3673,7 @@ class AnalyticsView {
     async _loadCrossToolTtftSection() {
         this._setSectionLoading('cross_tool_ttft');
         try {
-            const data = await this.api.getCrossToolTtft(this._timeParams());
+            const data = await this.api.getCrossToolTtft(this._baseParams());
             const rows = data.rows || [];
             if (!rows.length) {
                 this._setSectionBody('cross_tool_ttft', '<div class="empty-state-hint">No TTFT span data in this window. Only Claude Code and opencode spans carry ttft_ms.</div>');
@@ -3707,7 +3707,7 @@ class AnalyticsView {
     async _loadHookOverheadSection() {
         this._setSectionLoading('hook_overhead');
         try {
-            const data = await this.api.getHookOverhead(this._timeParams());
+            const data = await this.api.getHookOverhead(this._baseParams());
             const rows = data.rows || [];
             if (!rows.length) {
                 this._setSectionBody('hook_overhead', '<div class="empty-state-hint">No Codex hook data in this window.</div>');
@@ -3739,7 +3739,7 @@ class AnalyticsView {
     async _loadReasoningShareSection() {
         this._setSectionLoading('reasoning_share');
         try {
-            const data = await this.api.getReasoningShare(this._timeParams());
+            const data = await this.api.getReasoningShare(this._baseParams());
             const models = data.models || [];
             const effort = data.effort || [];
             if (!models.length && !effort.length) {

--- a/crates/otelite-api/tests/js/analytics_cross_tool_loaders.test.mjs
+++ b/crates/otelite-api/tests/js/analytics_cross_tool_loaders.test.mjs
@@ -1,0 +1,86 @@
+// Regression tests for the cross-tool report loaders (issue #189):
+// _loadCrossToolTtftSection, _loadHookOverheadSection and
+// _loadReasoningShareSection once called a nonexistent `this._timeParams()`
+// and failed with "Failed to load: this._timeParams is not a function" on
+// every expand. They must query the API with the standard time window
+// ({start_time, end_time} in ns, as produced by _baseParams).
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(join(here, '../../static/js/analytics.js'), 'utf8');
+const moduleObj = { exports: {} };
+new Function('module', 'exports', 'window', 'parseHashQuery', 'parseHashWindow', src)(
+    moduleObj,
+    moduleObj.exports,
+    undefined,
+    () => ({}),
+    () => null,
+);
+const { AnalyticsView } = moduleObj.exports;
+
+function makeView() {
+    const view = Object.create(AnalyticsView.prototype);
+    view.loadedSections = new Set();
+    view.trStart = new Date('2026-09-06T00:00:00Z');
+    view.trEnd = new Date('2026-09-07T00:00:00Z');
+    view._setSectionLoading = () => {};
+    view._bodies = {};
+    view._setSectionBody = (id, html) => {
+        view._bodies[id] = html;
+    };
+    return view;
+}
+
+const expectedParams = {
+    start_time: new Date('2026-09-06T00:00:00Z').getTime() * 1_000_000,
+    end_time: new Date('2026-09-07T00:00:00Z').getTime() * 1_000_000,
+};
+
+test('cross_tool_ttft loader queries the API with the standard time window', async () => {
+    const view = makeView();
+    const calls = [];
+    view.api = {
+        getCrossToolTtft: async (p) => {
+            calls.push(p);
+            return { rows: [] };
+        },
+    };
+    await view._loadCrossToolTtftSection();
+    assert.equal(calls.length, 1, 'getCrossToolTtft not called — loader threw?');
+    assert.deepEqual(calls[0], expectedParams);
+    assert.ok(view.loadedSections.has('cross_tool_ttft'));
+});
+
+test('hook_overhead loader queries the API with the standard time window', async () => {
+    const view = makeView();
+    const calls = [];
+    view.api = {
+        getHookOverhead: async (p) => {
+            calls.push(p);
+            return { rows: [] };
+        },
+    };
+    await view._loadHookOverheadSection();
+    assert.equal(calls.length, 1, 'getHookOverhead not called — loader threw?');
+    assert.deepEqual(calls[0], expectedParams);
+    assert.ok(view.loadedSections.has('hook_overhead'));
+});
+
+test('reasoning_share loader queries the API with the standard time window', async () => {
+    const view = makeView();
+    const calls = [];
+    view.api = {
+        getReasoningShare: async (p) => {
+            calls.push(p);
+            return { models: [], effort: [] };
+        },
+    };
+    await view._loadReasoningShareSection();
+    assert.equal(calls.length, 1, 'getReasoningShare not called — loader threw?');
+    assert.deepEqual(calls[0], expectedParams);
+    assert.ok(view.loadedSections.has('reasoning_share'));
+});


### PR DESCRIPTION
## What was wrong

Three analytics reports — Cross-Tool TTFT, Hook Overhead, Reasoning
Token Share (all added in e9e12c8) — failed on every expand with:

    Failed to load: this._timeParams is not a function

`_timeParams` was never defined on `AnalyticsView`; every other section
loader builds its window with `_baseParams()` (`{start_time, end_time}`
in ns).

## The fix

`this._timeParams()` → `this._baseParams()` at the three call sites
(analytics.js). Nothing else touched.

## Verification

- New node parity tests (`analytics_cross_tool_loaders.test.mjs`)
  invoke each loader against a stub `api` and assert the API call
  receives the standard time window. **Proven regression tests**: with
  the fix stashed, all 3 fail with the TypeError; with the fix, all 3
  pass.
- Full JS parity suite: 23/23.
- Quality gates: cargo build/test/clippy/fmt on the workspace.

Fixes #189.