### PR TITLE
Release pipeline: no admin-bypass push to main (release PRs + auto-merge)

### DIFF
--- a/.github/workflows/bump-and-tag.yml
+++ b/.github/workflows/bump-and-tag.yml
@@ -1,17 +1,33 @@
 name: Bump version and tag
 
-# Bumps version, creates a tag, publishes to crates.io, and triggers the dist
-# release workflow (binary builds + Homebrew formula update).
+# Release pipeline — no-override design (2026-09-08, closes #188):
 #
-# Triggers:
-#   - Every push to main bumps a patch version automatically.
-#   - Manual dispatch: Actions → Bump version and tag → Run workflow (patch/minor/major).
-#     CLI: gh workflow run bump-and-tag.yml --field bump=patch
+#   1. A push to main that ships release notes (bullets under
+#      '## [Unreleased]' or per-PR changelog/*.md entries) triggers a
+#      release.
+#   2. The release job opens a "chore: release vX.Y.Z" pull request
+#      carrying the version bump and the CHANGELOG rotation, waits for
+#      the required checks, and squash-merges it with GITHUB_TOKEN —
+#      the sanctioned path under branch protection. No admin-bypass
+#      credential is involved anywhere in a normal release.
+#   3. The merged commit is tagged vX.Y.Z (tags are not branch
+#      protected), release.yml is dispatched for the binary builds,
+#      GitHub release and Homebrew formula, and the crates.io publish
+#      runs as the reusable job below.
 #
-# Note: GITHUB_TOKEN tag pushes do NOT trigger other workflow `push: tags:` listeners
-# (GitHub design). Binary releases are triggered via `gh workflow run dist-release.yml`.
-# This requires RELEASE_TOKEN (PAT with `repo` + `workflow` scopes) to be set as a secret.
-# Without RELEASE_TOKEN, binary builds must be started manually after the tag is created.
+#   Runs are serialised (concurrency group `release`) and always build
+#   the release from the *latest* main, so back-to-back merges either
+#   combine into one release or chain cleanly.
+#
+#   Manual dispatch (patch/minor/major) cuts a release on demand when
+#   main carries notes a push did not release; with no notes it exits
+#   cleanly.
+#
+#   Incident recovery (the only place override belongs): if a release
+#   PR gets stuck, re-run the failed jobs (Actions → run → Re-run
+#   failed) and merge by hand (`gh pr merge <n> --squash
+#   --delete-branch`), tag the merged commit and dispatch release.yml —
+#   or push the tagged commit to main with owner credentials.
 
 on:
   push:
@@ -33,17 +49,22 @@ env:
 
 permissions:
   contents: write
+  actions: write
+  pull-requests: write
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   release:
-    name: Bump version and tag
+    name: Open and merge release PR
     runs-on: ubuntu-latest
-    # Guard: the version-bump commit must not re-trigger this workflow.
+    timeout-minutes: 90
+    # Guard: a release PR's own merge must not re-trigger this workflow.
     if: "!startsWith(github.event.head_commit.message, 'chore: release v')"
     outputs:
       new_version: ${{ steps.bump.outputs.new }}
-    env:
-      RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
     steps:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
@@ -55,11 +76,36 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: Sync to latest main and gate on release notes
+        # Always build the release from the *latest* main, not this
+        # push's commit: under the concurrency group a later run can
+        # start after an earlier release already consumed this push's
+        # notes, in which case there is nothing to release.
+        id: gate
+        run: |
+          set -euo pipefail
+          git fetch -q origin main
+          git checkout -q -B release-base origin/main
+          unreleased_has=0
+          awk '/^## \[Unreleased\]/{f=1;next} f&&/^## /{f=0} f' CHANGELOG.md | grep -qE '^- ' && unreleased_has=1
+          entry_has=0
+          for f in $(find changelog -maxdepth 1 -name '*.md' ! -name '.*' 2>/dev/null | sort); do
+            if grep -qE '^- ' "$f"; then entry_has=1; break; fi
+          done
+          if [[ "$unreleased_has" -eq 0 && "$entry_has" -eq 0 ]]; then
+            echo "main carries no release notes — nothing to release (skipping)."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Bump version in Cargo.toml
         id: bump
+        if: steps.gate.outputs.proceed == 'true'
         env:
           BUMP_KIND: ${{ inputs.bump || 'patch' }}
         run: |
+          set -euo pipefail
           current=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
           IFS='.' read -r major minor patch <<< "$current"
           case "$BUMP_KIND" in
@@ -72,55 +118,157 @@ jobs:
           echo "new=$new" >> "$GITHUB_OUTPUT"
 
       - uses: actions-rust-lang/setup-rust-toolchain@166cdcfd11aee3cb47222f9ddb555ce30ddb9659 # v1
+        if: steps.gate.outputs.proceed == 'true'
         with:
           toolchain: stable
 
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-
       - name: Update Cargo.lock
+        if: steps.gate.outputs.proceed == 'true'
         run: cargo metadata --format-version 1 > /dev/null
 
       - name: Rotate CHANGELOG [Unreleased] → [X.Y.Z]
         # Fails if [Unreleased] is empty — every release must ship with notes.
         # See AGENTS.md → Changelog discipline.
-        run: |
-          ./scripts/rotate-changelog.sh "${{ steps.bump.outputs.new }}"
+        if: steps.gate.outputs.proceed == 'true'
+        run: ./scripts/rotate-changelog.sh "${{ steps.bump.outputs.new }}"
 
-      - name: Commit, tag, and push
-        # GITHUB_TOKEN pushes are refused on a PR-protected main (by design:
-        # any collaborator could otherwise route a workflow to push to main),
-        # so the release commit goes out with the PAT that already carries
-        # `repo` scope for this workflow — the same token used for the
-        # release dispatch below.
+      - name: Commit and open release PR
+        id: pr
+        if: steps.gate.outputs.proceed == 'true'
         env:
-          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          NEW_VERSION: ${{ steps.bump.outputs.new }}
         run: |
+          set -euo pipefail
+          branch="chore/release-v${NEW_VERSION}"
+          git checkout -q -b "$branch"
           git add Cargo.toml Cargo.lock CHANGELOG.md changelog/
-          git commit -m "chore: release v${{ steps.bump.outputs.new }}"
-          git tag "v${{ steps.bump.outputs.new }}"
-          git push "https://x-access-token:${RELEASE_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" main "v${{ steps.bump.outputs.new }}"
+          git commit -m "chore: release v${NEW_VERSION}"
+          git push -q origin "$branch"
+          body=$(printf 'Automatic release PR opened by the *Bump version and tag* workflow.\n\nCarries the version bump (Cargo.toml / Cargo.lock) and the CHANGELOG rotation for v%s. It merges by itself once the required checks pass — no manual action needed.\n\nIf a required check fails spuriously it is re-run once automatically; if it fails again, re-run it (Actions → run → Re-run failed jobs) and the merge will proceed, or merge by hand (gh pr merge <n> --squash --delete-branch), then tag the merged commit and dispatch release.yml.' "$NEW_VERSION")
+          url=$(gh pr create --title "chore: release v${NEW_VERSION}" --body "$body")
+          pr_number=${url##*/}
+          echo "pr_number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+          echo "opened $url"
+
+      - name: Wait for checks, rebase if stale, squash-merge
+        id: merge
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          BRANCH: ${{ steps.pr.outputs.branch }}
+        run: |
+          set -uo pipefail
+          merged=0
+          reran=0
+          for i in $(seq 1 50); do
+            status=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus 2>/dev/null || echo UNKNOWN)
+            case "$status" in
+              CLEAN|UNSTABLE)
+                # Capture main's head immediately before merging so the
+                # tag step can prove it tagged the exact squash commit.
+                git fetch -q origin main
+                echo "base_before=$(git rev-parse origin/main)" >> "$GITHUB_OUTPUT"
+                gh pr merge "$PR_NUMBER" --squash --delete-branch
+                echo "release PR #$PR_NUMBER squash-merged"
+                merged=1
+                break
+                ;;
+              BEHIND|HAS_COMMITS_BEHIND)
+                echo "main moved — rebasing $BRANCH onto latest main (checks re-run)"
+                git fetch -q origin main
+                if ! git rebase -q origin/main; then
+                  echo "rebase conflict — release needs manual intervention"
+                  exit 1
+                fi
+                git push -q -f origin "$BRANCH"
+                ;;
+              DIRTY)
+                echo "merge conflict on $BRANCH — release needs manual intervention"
+                exit 1
+                ;;
+              BLOCKED)
+                # Required checks not met. Conclude failure only once
+                # every check has settled (stale conclusions from a
+                # superseded head must not count).
+                head_oid=$(gh pr view "$PR_NUMBER" --json headRefOid -q .headRefOid 2>/dev/null || echo "")
+                if [[ -n "$head_oid" ]]; then
+                  runs=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${head_oid}/check-runs" \
+                    -q '[.check_runs[] | {status: .status, conclusion: (.conclusion // "none")}]' 2>/dev/null || echo "[]")
+                  in_progress=$(jq '[.[] | select(.status != "completed")] | length' <<<"$runs")
+                  settled_failures=$(jq '[.[] | select(.status == "completed" and (.conclusion | ascii_downcase | IN("failure","error","timed_out","cancelled")))] | length' <<<"$runs")
+                  if [[ "$in_progress" -eq 0 && "$settled_failures" -gt 0 ]]; then
+                    if [[ "$reran" -eq 0 ]]; then
+                      echo "settled failure — re-running failed jobs once, then waiting again"
+                      gh run list --branch "$BRANCH" --limit 25 --json databaseId,conclusion \
+                        -q '.[] | select(.conclusion == "failure") | .databaseId' | while read -r id; do
+                        gh run rerun "$id" --failed || true
+                      done
+                      reran=1
+                    else
+                      echo "check(s) still failing after re-run — release needs manual intervention:"
+                      jq -r '.[] | select(.status == "completed" and (.conclusion | ascii_downcase | IN("failure","error","timed_out","cancelled"))) | .conclusion' <<<"$runs" | sort | uniq -c
+                      exit 1
+                    fi
+                  else
+                    echo "checks in flight — waiting (attempt $i/50)"
+                  fi
+                else
+                  echo "checks in flight — waiting (attempt $i/50)"
+                fi
+                ;;
+              *)
+                echo "merge state '$status' — waiting (attempt $i/50)"
+                ;;
+            esac
+            sleep 60
+          done
+          if [[ "$merged" -ne 1 ]]; then
+            echo "timed out waiting for the release PR to go green — manual intervention"
+            exit 1
+          fi
+
+      - name: Tag merged commit and push
+        if: steps.gate.outputs.proceed == 'true'
+        env:
+          NEW_VERSION: ${{ steps.bump.outputs.new }}
+          BASE_BEFORE: ${{ steps.merge.outputs.base_before }}
+        run: |
+          set -euo pipefail
+          git fetch -q origin main
+          # The squash commit's parent must be exactly the main head we
+          # captured pre-merge — otherwise main advanced in the window
+          # and we would tag the wrong commit.
+          if [[ "$(git rev-parse origin/main^)" != "$BASE_BEFORE" ]]; then
+            echo "main advanced between merge and tag — manual intervention"
+            exit 1
+          fi
+          git tag "v${NEW_VERSION}" origin/main
+          git push -q origin "v${NEW_VERSION}"
+          echo "tagged v${NEW_VERSION} at $(git rev-parse --short origin/main)"
 
       - name: Trigger binary release workflow
-        # Requires RELEASE_TOKEN (PAT with repo + workflow scopes).
-        # Without it, binary builds must be triggered manually.
-        if: ${{ env.RELEASE_TOKEN != '' }}
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        # GITHUB_TOKEN with `actions: write` (see workflow permissions).
+        # Tag pushes do not trigger `push: tags:` listeners (GitHub
+        # design), so the dispatch is explicit.
+        if: steps.gate.outputs.proceed == 'true'
         run: |
-          gh workflow run release.yml \
-            --ref "v${{ steps.bump.outputs.new }}" \
-            --repo "${{ github.repository }}"
+          gh workflow run release.yml --ref "v${{ steps.bump.outputs.new }}" --repo "${{ github.repository }}"
+          echo "release.yml dispatched for v${{ steps.bump.outputs.new }}"
 
       - name: Summary
+        if: steps.gate.outputs.proceed == 'true'
         run: |
-          echo "### Released v${{ steps.bump.outputs.new }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "Bumped \`${{ steps.bump.outputs.old }}\` → \`${{ steps.bump.outputs.new }}\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "Tag \`v${{ steps.bump.outputs.new }}\` pushed — publish workflow triggered." >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo "### Released v${{ steps.bump.outputs.new }}"
+            echo "Bumped \`${{ steps.bump.outputs.old }}\` → \`${{ steps.bump.outputs.new }}\`"
+            echo "Release PR #${{ steps.pr.outputs.pr_number }} squash-merged, tag pushed, release.yml dispatched."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   publish:
     name: Publish to crates.io
     needs: release
+    if: needs.release.result == 'success' && needs.release.outputs.new_version != ''
     uses: ./.github/workflows/publish.yml
     with:
       ref: "v${{ needs.release.outputs.new_version }}"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -22,7 +22,10 @@ jobs:
         run: |
           set -euo pipefail
           base=$(git merge-base origin/main HEAD)
-          changed=$(git diff --name-only "$base" HEAD)
+          # ACM only: the auto-merged release PR *deletes* the consumed
+          # changelog/*.md entries, and 'git show HEAD:<deleted>' would
+          # error. Release PRs pass via the CHANGELOG.md branch below.
+          changed=$(git diff --name-only --diff-filter=ACM "$base" HEAD)
 
           entry=$(printf '%s\n' "$changed" | grep -E '^changelog/[^/]+\.md$' | head -1 || true)
           if [[ -n "$entry" ]]; then

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -50,7 +50,15 @@ jobs:
   nix-check:
     name: Flake Check
     needs: changes
-    if: github.event_name != 'pull_request' || needs.changes.outputs.changed == 'true'
+    # Release PRs (chore/release-v*) carry only the version bump and the
+    # changelog rotation on top of an already-green main — no new code —
+    # yet the flake check is the longest, most variable required check
+    # (14-40 min observed), so it is excluded from the release critical
+    # path. A skipped required check does not block the merge (same
+    # mechanism as the self-skip above).
+    if: >
+      github.event_name != 'pull_request' ||
+      (needs.changes.outputs.changed == 'true' && !startsWith(github.head_ref, 'chore/release-v'))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,19 +179,27 @@ changes, CI/release plumbing, dependency bumps with no behaviour change.
    `CHANGELOG.md` — it is the release-generated record, and concurrent
    edits to it are what used to make open PRs clash on every release
    rotation.
-2. At release time, the bump-and-tag CI workflow runs
-   `scripts/rotate-changelog.sh`, which merges any `[Unreleased]` bullets
-   and every `changelog/*.md` entry into `[X.Y.Z] - YYYY-MM-DD` (canonical
-   section order: Added, Changed, Fixed, Removed, Internal) and deletes the
-   consumed entry files. The script **fails the release** if neither source
-   has at least one bullet.
+2. At release time, the bump-and-tag CI workflow opens an auto-merged
+   **release PR** (`chore: release vX.Y.Z`) carrying the
+   `Cargo.toml`/`Cargo.lock` version bump and the
+   `scripts/rotate-changelog.sh` rotation (merges any `[Unreleased]`
+   bullets and every `changelog/*.md` entry into `[X.Y.Z] - YYYY-MM-DD`,
+   canonical section order: Added, Changed, Fixed, Removed, Internal, and
+   deletes the consumed entry files). The release PR merges by itself once
+   the required checks pass, then the merged commit is tagged and the
+   binary release + crates.io publish are triggered — no admin-bypass
+   credential is used (see #188). The script **fails the release** if
+   neither source has at least one bullet. Leave release PRs alone; if one
+   gets stuck, re-run the failed checks or merge it by hand (the incident
+   path is documented in `bump-and-tag.yml`).
 3. Bullets may still be appended under `## [Unreleased]` directly for
    changes made on main itself; both sources merge into the release section.
 4. For pure-plumbing pushes with no user impact, add an `### Internal`
    bullet (entry file or `[Unreleased]`). This satisfies the gate without
    inventing fake user-facing copy.
-5. If the bump fails because no notes were found, add the missing entry and
-   push — the workflow retries automatically on the next push to main.
+5. A push with no release notes exits the workflow cleanly (nothing to
+   release) — if you expected a release, check the bump-and-tag run's gate
+   step, or trigger one manually (Actions → Bump version and tag).
 
 Test the script: `scripts/rotate-changelog.sh --selftest`.
 Dry-run the rotation locally:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,10 @@ Ship your release notes as a separate entry file — **do not edit
    `### Added` / `### Changed` / `### Fixed` / `### Removed` /
    `### Internal`; a file with no heading defaults to Added.
 3. The release workflow merges entry files into the next release section of
-   `CHANGELOG.md` and deletes them.
+   `CHANGELOG.md` and deletes them. This ships as an auto-merged
+   `chore: release vX.Y.Z` PR (version bump + rotation) that merges itself
+   once checks pass — leave it alone; if it gets stuck, see the incident
+   note in `.github/workflows/bump-and-tag.yml`.
 
 Why not edit `CHANGELOG.md` directly? Every push to main rotates the
 changelog (a new release is cut), so a PR holding a `CHANGELOG.md` hunk

--- a/changelog/199.md
+++ b/changelog/199.md
@@ -1,0 +1,9 @@
+### Internal
+
+- Releases no longer require an admin-bypass credential: the version
+  bump and changelog rotation now ship as an auto-merged release PR
+  (`chore: release vX.Y.Z`) that goes through the normal
+  protected-branch flow, then the merged commit is tagged and the
+  binary release + crates.io publish are triggered. Override (an
+  owner-key push to main) is reserved for bootstrap and incident
+  recovery only (#188).


### PR DESCRIPTION
## What changed

Fixes #188. The release pipeline no longer needs a credential that can
override branch protection.

**Before:** bump-and-tag pushed the release commit (version bump +
changelog rotation) directly to main with an owner-scoped PAT
(`RELEASE_TOKEN`). Every release was an admin-bypass push; the current
token cannot bypass (GH006), so five straight releases needed manual
recovery.

**After:**
- the bump workflow (push to main carrying release notes) opens a
  `chore: release vX.Y.Z` PR with the version bump + CHANGELOG rotation
  and squash-merges it with `GITHUB_TOKEN` once the required checks pass
  — the sanctioned path under protection
- wait loop: rebases onto main if it moves, auto re-runs a settled
  failure once, fails loudly on conflict / persistent failure / timeout
  (incident path documented in the workflow header)
- tags the merged commit with a parent check (a concurrent main move
  between merge and tag fails loudly rather than mistagging), pushes the
  tag, dispatches `release.yml` with `GITHUB_TOKEN` (`actions: write`);
  the crates.io publish stays a reusable job in the same workflow
- concurrency group `release` serialises runs; each builds the release
  from the *latest* main and exits cleanly when it carries no notes

Supporting fixes:
- `changelog.yml`: entry detection ignores deleted files
  (`--diff-filter=ACM`) — release PRs delete the consumed
  `changelog/*.md`, which would otherwise make the check fail on
  `git show HEAD:<deleted>`
- `nix.yml`: flake check excluded from release PRs (version strings over
  an already-green main; 14-40 min observed — the longest, most variable
  required check). A skipped required check does not block the merge,
  same mechanism as the existing self-skip
- AGENTS.md / CONTRIBUTING.md: document the release-PR flow and the
  incident path

## Verification

- `actionlint` clean on all three workflows; `bash -n` on every inline
  script
- gate logic dry-run locally in both directions (current main → skip;
  entry file present → proceed)
- end-to-end proof is the merge itself: this lands release **0.1.125**
  through the new flow — release PR → checks → auto-merge → tag → GH
  release + Homebrew + crates.io, zero override
- `RELEASE_TOKEN` becomes unused and can be deleted from repo secrets
  once 0.1.125 ships cleanly (pending your go-ahead)
