### PR TITLE
Release pipeline fix: GH_TOKEN for the gh CLI + idempotent branch re-push

### DIFF
--- a/.github/workflows/bump-and-tag.yml
+++ b/.github/workflows/bump-and-tag.yml
@@ -61,6 +61,10 @@ jobs:
     name: Open and merge release PR
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    # The gh CLI does not auto-use GITHUB_TOKEN in Actions; point it at the
+    # workflow token so pr create / pr view / pr merge / workflow run work.
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     # Guard: a release PR's own merge must not re-trigger this workflow.
     if: "!startsWith(github.event.head_commit.message, 'chore: release v')"
     outputs:
@@ -143,7 +147,9 @@ jobs:
           git checkout -q -b "$branch"
           git add Cargo.toml Cargo.lock CHANGELOG.md changelog/
           git commit -m "chore: release v${NEW_VERSION}"
-          git push -q origin "$branch"
+          # Force: a re-run after a mid-release failure pushes a fresh
+          # commit (new timestamp) onto the branch the failed run left.
+          git push -q -f origin "$branch"
           body=$(printf 'Automatic release PR opened by the *Bump version and tag* workflow.\n\nCarries the version bump (Cargo.toml / Cargo.lock) and the CHANGELOG rotation for v%s. It merges by itself once the required checks pass — no manual action needed.\n\nIf a required check fails spuriously it is re-run once automatically; if it fails again, re-run it (Actions → run → Re-run failed jobs) and the merge will proceed, or merge by hand (gh pr merge <n> --squash --delete-branch), then tag the merged commit and dispatch release.yml.' "$NEW_VERSION")
           url=$(gh pr create --title "chore: release v${NEW_VERSION}" --body "$body")
           pr_number=${url##*/}

--- a/changelog/200.md
+++ b/changelog/200.md
@@ -1,0 +1,6 @@
+### Internal
+
+- Release pipeline fix: the auto-merged release PR flow now sets
+  `GH_TOKEN` for the GitHub CLI (the first 0.1.125 attempt failed at
+  the `gh pr create` step) and force-pushes the release branch so a
+  re-run replaces a branch left behind by a failed attempt.


### PR DESCRIPTION
## What changed

Follow-up to #199. The first 0.1.125 attempt ran the new flow correctly
through gate → version bump → CHANGELOG rotation → branch push
(`chore/release-v0.1.125`), then failed at `gh pr create`:

> To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN
> environment variable.

The `gh` CLI does not auto-use `GITHUB_TOKEN` in Actions (the old
workflow set `GH_TOKEN` per-step for its dispatch). Two fixes:

- `GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` at the release-job level —
  pr create / pr view / pr merge / workflow run all inherit it
- force-push the release branch, so a re-run after a mid-release failure
  replaces the branch the failed run left behind instead of being
  rejected non-fast-forward

## Verification

- actionlint clean
- the merge itself is the test: this push carries a changelog entry, so
  it triggers release **0.1.125** through the corrected flow — release
  PR → checks → auto-merge → tag → GH release + Homebrew + crates.io
  (the leftover branch from the failed attempt gets force-replaced)